### PR TITLE
fix: resolve edge function Deno lint failure

### DIFF
--- a/supabase/functions/process-voter-file/index.ts
+++ b/supabase/functions/process-voter-file/index.ts
@@ -121,7 +121,7 @@ serve(async (req) => {
       error_message: insertError ? insertError.message : null,
       completed_at: new Date().toISOString(),
     });
-  } catch (err) {
+  } catch (_err) {
     // Log but do not fail the function if this insert fails
   }
 


### PR DESCRIPTION
## Summary

- Prefix unused `catch (err)` with underscore (`_err`) in `supabase/functions/process-voter-file/index.ts:124` to satisfy Deno's `no-unused-vars` lint rule
- This was blocking CI on the `v0.1.0-alpha.1` tag push ([failed run](https://github.com/civictechdc/votecatcher/actions/runs/24301889541))

## Test plan

- [ ] CI edge-functions-check job passes on this PR