### PR TITLE
docs: community docs, issue templates, and security policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,94 @@
+name: Bug report
+description: Report a bug or unexpected behavior
+labels: ['bug', 'triage']
+assignees: []
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: A brief description of the bug
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction-steps
+    attributes:
+      label: Reproduction steps
+      description: Steps to reproduce the bug
+      placeholder: |
+        1. Go to...
+        2. Click...
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected behavior
+      description: What you expected to happen
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: Actual behavior
+      description: What actually happened
+    validations:
+      required: true
+
+  - type: dropdown
+    id: environment
+    attributes:
+      label: Environment
+      options:
+        - Docker
+        - Local dev (Python + Bun)
+        - Dev Container
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: browser
+    attributes:
+      label: Browser (if applicable)
+      description: Browser and version (e.g., Chrome 123, Firefox 124)
+    validations:
+      required: false
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - Low - Minor inconvenience
+        - Medium - Workaround available
+        - High - Major feature broken
+        - Critical - Data loss or security issue
+    validations:
+      required: true
+
+  - type: textarea
+    id: screenshots-logs
+    attributes:
+      label: Screenshots/logs
+      description: Add any relevant screenshots or logs
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Any other context about the problem
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Slack #vote_catcher
+    url: https://civictechdc.slack.com/archives/C04U3D9AWER
+    about: Ask questions and discuss with the community
+  - name: Contributing Guide
+    url: https://github.com/civictechdc/votecatcher/blob/main/CONTRIBUTING.md
+    about: Development setup, code standards, and PR process

--- a/.github/ISSUE_TEMPLATE/custom.yml
+++ b/.github/ISSUE_TEMPLATE/custom.yml
@@ -1,0 +1,26 @@
+name: Custom issue
+description: Use this template for any other type of issue
+labels: ['triage']
+assignees: []
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for issues that don't fit the other categories.
+
+  - type: input
+    id: title
+    attributes:
+      label: Title
+      description: A brief title for your issue
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Provide a detailed description of your issue
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,56 @@
+name: Documentation
+description: Report an issue with documentation
+labels: ['documentation', 'triage']
+assignees: []
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve our documentation!
+
+  - type: textarea
+    id: what-needs-changing
+    attributes:
+      label: What needs changing
+      description: Describe the documentation issue
+    validations:
+      required: true
+
+  - type: input
+    id: location
+    attributes:
+      label: Location
+      description: File or section that needs updating
+      placeholder: "e.g., README.md, docs/configuration-modes.md"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: type-of-change
+    attributes:
+      label: Type of change
+      options:
+        - Typo/grammar fix
+        - Missing documentation
+        - Outdated information
+        - New documentation needed
+        - Unclear/confusing content
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggested-fix
+    attributes:
+      label: Suggested fix
+      description: If you have a specific change in mind, describe it here
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Any other relevant information
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,54 @@
+name: Feature request
+description: Suggest a new feature or enhancement
+labels: ['enhancement', 'triage']
+assignees: []
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a new feature!
+
+  - type: textarea
+    id: problem-statement
+    attributes:
+      label: Problem statement
+      description: What problem does this solve?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Proposed solution
+      description: What would you like to see implemented?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives-considered
+    attributes:
+      label: Alternatives considered
+      description: Have you considered any alternative solutions or workarounds?
+    validations:
+      required: false
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      options:
+        - Small - Single component
+        - Medium - Multiple components
+        - Large - Architecture change
+        - Unknown
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Any other context or requirements
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/spike_research.yml
+++ b/.github/ISSUE_TEMPLATE/spike_research.yml
@@ -1,0 +1,55 @@
+name: Spike/Research
+description: Research task to investigate a question or topic
+labels: ['spike', 'triage']
+assignees: []
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for research tasks and spikes.
+
+  - type: textarea
+    id: question-or-topic
+    attributes:
+      label: Question or topic
+      description: What question are you trying to answer?
+    validations:
+      required: true
+
+  - type: textarea
+    id: context-and-motivation
+    attributes:
+      label: Context and motivation
+      description: Why is this research needed? What decisions depend on this?
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance criteria
+      description: What constitutes a sufficient answer? What deliverables are expected?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: time-box
+    attributes:
+      label: Time-box
+      options:
+        - 1 hour
+        - 2 hours
+        - Half day
+        - Full day
+        - Multi-day
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Any other context or resources
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+## Summary
+<!-- Describe the changes in this PR -->
+
+## Related Issue
+<!-- Link to the issue this PR closes (e.g., Closes #123) -->
+Closes #
+
+## Change Type
+<!-- Check all that apply -->
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor
+- [ ] Documentation
+- [ ] CI/CD
+- [ ] Other
+
+## Testing
+<!-- Check all that apply -->
+- [ ] Unit tests pass
+- [ ] Manual testing done
+- [ ] E2E tests added/updated
+
+## Screenshots
+<!-- Add screenshots if UI changes. Delete if not applicable -->
+
+
+## Checklist
+- [ ] PR targets main
+- [ ] Self-reviewed
+- [ ] Added tests
+- [ ] No breaking changes
+- [ ] Updated documentation

--- a/.github/workflows/sync-coc.yml
+++ b/.github/workflows/sync-coc.yml
@@ -1,0 +1,71 @@
+name: Sync Code of Conduct
+
+on:
+  schedule:
+    - cron: '0 0 1 */3 *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync-coc:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Fetch upstream Code of Conduct
+        id: fetch
+        run: |
+          UPSTREAM_CONTENT=$(gh api repos/civictechdc/code-of-conduct/contents/CodeofConduct.md --jq '.content' | base64 -d)
+          echo "content<<EOF" >> $GITHUB_OUTPUT
+          echo "$UPSTREAM_CONTENT" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compare with local
+        id: compare
+        run: |
+          LOCAL_CONTENT=$(cat CODE_OF_CONDUCT.md)
+          UPSTREAM_CONTENT="${{ steps.fetch.outputs.content }}"
+
+          if [ "$LOCAL_CONTENT" = "$UPSTREAM_CONTENT" ]; then
+            echo "changed=false" >> $GITHUB_OUTPUT
+            echo "No changes detected"
+          else
+            echo "changed=true" >> $GITHUB_OUTPUT
+            echo "Changes detected"
+            echo "$UPSTREAM_CONTENT" > CODE_OF_CONDUCT.md
+          fi
+
+      - name: Create PR if changed
+        if: steps.compare.outputs.changed == 'true'
+        run: |
+          BRANCH="sync/code-of-conduct-$(date +%Y%m%d)"
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git checkout -b "$BRANCH"
+          git add CODE_OF_CONDUCT.md
+          git commit -m 'chore: update Code of Conduct from upstream'
+          git push origin "$BRANCH"
+
+          DIFF=$(git diff main.."$BRANCH" -- CODE_OF_CONDUCT.md)
+          gh pr create \
+            --title 'chore: update Code of Conduct from upstream' \
+            --body "Updates CODE_OF_CONDUCT.md from [civictechdc/code-of-conduct](https://github.com/civictechdc/code-of-conduct).
+
+          <details><summary>Diff</summary>
+
+          \`\`\`diff
+          ${DIFF}
+          \`\`\`
+
+          </details>" \
+            --base main \
+            --head "$BRANCH" \
+            --label 'documentation'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,92 @@
+# Code of Conduct
+
+**This code may be summed up simply: Be Kind.** However, since this does not always happen, we have elaborated on this principle below.
+
+Civic Tech DC is an organization working, as a group, to empower ourselves and others to improve our local community through technology.
+
+We are committed to providing a safe and welcoming space, without regard to age, gender, race, ethnicity, nationality, sexual orientation, gender identity, gender expression, mental or physical disability, physical appearance, neuro(a)typicality, religion, level of knowledge, level of experience, parental status, marital status, socioeconomic status or background, political affiliation, or any other attribute. The organizers of Civic Tech DC ("Organizers") share the responsibility of enforcing these policies as necessary to maintain an open and welcoming environment.
+
+As the organizers of Civic Tech DC, we believe that the principles below are essential to maintaining this environment. In addition, we believe they are good principles for life in general.
+
+## Applicability
+
+This Code of Conduct serves to ensure that everybody and anybody who wishes to participate is able to do so and applies to all Civic Tech DC events, from hackathons to happy hours. Further, it applies to online activities related to Civic Tech DC, including postings on GitHub, Slack, and Google Groups.
+
+## Principles
+
+### Do Not Harass
+
+Harassment is any unwelcome or hostile behavior towards another person for any reason. This includes, but is not limited to:
+
+* Offensive verbal comments related to personal characteristics or choices
+* Sexual images or comments
+* Deliberate intimidation, bullying, stalking, following
+* Harassing photography or recording
+* Sustained disruption of discussion or events
+* Nonconsensual publication of private comments
+* Inappropriate physical contact
+* Unwelcome sexual advances or attention
+* Any conduct that makes others uncomfortable
+
+Conduct need not be intentional to be harassment. **Civic Tech DC will not tolerate such behavior.**
+
+### Respect the Opinions and Abilities of Others
+
+Civic Tech DC is designed as a place for people of all different skill levels and approaches to meet and work together toward common goals. We do not expect that everybody will share the same opinion, but we do expect that disagreement is done respectfully.
+
+Additionally, we expect that members will educate others respectfully. Do not assume anybody else's level of expertise or knowledge. Do not belittle a lack of information, or insist on unnecessary precision. We are all learning, so afford others—as well as yourself—room to grow.
+
+### Keep Your Team Open
+
+Except for instances where it would significantly impede productivity, there is always room on a Civic Tech DC project for one more person. Unless doing so would be counter-productive to the goals of the project, anybody who is interested in a project is allowed to join it.
+
+## Aspirations
+
+While this document exists primarily to prevent certain bad behavior, we also believe that our community members should work towards a higher standard. To that end, we strongly encourage the following conduct, though they are considered aspirational rather than necessary.
+
+### Build With, Not For
+
+Work to ensure that the community is well-represented in all stages of development. Seek out those who are under-represented, and remove barriers to access. Listen as much—or more—than you speak, and give full consideration to all ideas, even if they seem improbable at first.
+
+### Empower, Experiment, and Find a Way for Everybody to Contribute
+
+When more people share their knowledge and skills, they give a project a greater chance to succeed. When somebody shows up with an unusual skill, look for ways to fit them into the team rather than reasons why it wouldn't work. Experiment with new approaches, and don't be afraid to try something that might not work.
+
+## Photography
+
+Please be aware that in order to grow and promote our organization, for general record keeping, and to build community amongst our participants, photography and videography often occur at our events. Participation at our events is voluntary. By participating in our events, it is understood that your image or likeness may be included in the photography or videography and shared on public websites and media content. If you would like further information about this policy, please contact [team@civictechdc.org](mailto:team@civictechdc.org).
+
+## Procedures
+
+### Making a Report
+
+If you are unable to resolve the issue, or are uncomfortable doing so, you should contact a Organizer, either in person or electronically. You can email us at **[team@civictechdc.org](mailto:team@civictechdc.org)**, which goes to all of the leadership team. Contact information for each Organizer is listed on our About page; please note that electronic reports may not be seen immediately during an event. Organizers agree to keep information shared in association with a Code of Conduct violation private, and may reveal it only with the approval of the affected person(s).
+
+Alternatively, you may submit issues **anonymously** using our feedback form: [https://forms.gle/xNkayfBVMJj8dt1X8](https://forms.gle/xNkayfBVMJj8dt1X8)
+
+When making a report, the following information is useful, but not required:
+
+* Who violated the Code of Conduct?
+* Where and when did the violation occur?
+* What happened?
+* Who may have witnessed the violation?
+* Who are you?
+
+### Outcomes
+
+Organizers agree to treat all violations impartially and will strive to apply this Code of Conduct consistently. In situations where this may not be possible due to personal or business relationships, Organizers shall refer the violation report to another appropriate decision-maker with the approval of the affected person(s).
+
+Organizers may take any of the following actions, or other appropriate actions, to resolve a conduct issue:
+
+* **Individual Meeting:** A meeting between the party responsible for the conduct and Organizer(s).
+* **Group Meeting:** A meeting between the parties involved, with Organizer mediation.
+* **Team Realignment:** Members may be asked to work on a different project. This action shall not be used as a punitive measure against the affected party.
+* **Expulsion:** In extreme situations, the offending party will be barred from future Civic Tech DC events.
+
+In the event of gray areas, precedence will be given to the target of the conduct.
+
+## Contributing to This Code
+
+This is a living document and is ultimately owned by the Civic Tech DC community. We are interested in your comments and suggestions! You can contribute to the code by opening an issue or pull request on this repository or by contacting the leadership team at **[team@civictechdc.org](mailto:team@civictechdc.org)**.
+
+This code and other documents in this repository are dedicated to the public domain under a **CC0 license**. By contributing to this repository, you agree to release your contribution to the public domain.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -202,6 +202,9 @@ just migrate-down                 # Rollback
 
 ## Getting Help
 
-- Open an issue for bugs or feature requests
-- Check [docs/](docs/) for detailed documentation
+- **Slack:** Join the conversation in [#vote_catcher](https://civictechdc.slack.com/archives/C04U3D9AWER) on the [CivicTech DC Slack](https://www.civictechdc.org/)
+- **Issues:** Open a [bug report](https://github.com/civictechdc/votecatcher/issues/new?template=bug_report.yml) or [feature request](https://github.com/civictechdc/votecatcher/issues/new?template=feature_request.yml)
+- **Security:** Report vulnerabilities privately via [GitHub Security Advisories](https://github.com/civictechdc/votecatcher/security/advisories/new) — see [SECURITY.md](SECURITY.md)
+- **Code of Conduct:** All participants must follow the [Code of Conduct](CODE_OF_CONDUCT.md)
+- **Docs:** Check [docs/](docs/) for detailed documentation
 - Run `just` to see all available commands

--- a/README.md
+++ b/README.md
@@ -9,10 +9,11 @@ Automate ballot signature recognition and validation. Put powerful organizing to
 [![CI](https://github.com/civictechdc/votecatcher/actions/workflows/ci.yml/badge.svg)](https://github.com/civictechdc/votecatcher/actions/workflows/ci.yml)
 [![Security](https://github.com/civictechdc/votecatcher/actions/workflows/security.yml/badge.svg)](https://github.com/civictechdc/votecatcher/actions/workflows/security.yml)
 [![Version](https://img.shields.io/badge/dynamic/toml?url=https%3A%2F%2Fraw.githubusercontent.com%2Fcivictechdc%2Fvotecatcher%2Fmain%2Fbackend%2Fpyproject.toml&query=%24.project.version&label=version&color=green)](https://github.com/civictechdc/votecatcher/releases)
-[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-3776AB.svg?logo=python&logoColor=white)](https://www.python.org/downloads/)
 [![SvelteKit](https://img.shields.io/badge/SvelteKit-5-FF3E00.svg?logo=svelte&logoColor=white)](https://kit.svelte.dev)
 [![Docker](https://img.shields.io/badge/Docker-ready-2496ED.svg?logo=docker&logoColor=white)](https://www.docker.com/)
+[![Slack](https://img.shields.io/badge/Slack-%23vote__catcher-4A154B.svg?logo=slack&logoColor=white)](https://civictechdc.slack.com/archives/C04U3D9AWER)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 </div>
 
@@ -232,6 +233,17 @@ For full configuration details, see [Configuration Modes](docs/configuration-mod
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, code standards, and PR process.
+
+## Community
+
+VoteCatcher is a [CivicTech DC](https://www.civictechdc.org/) project. We're building open source campaign infrastructure to put powerful organizing tools in the hands of grassroots campaigns.
+
+| Resource | Link |
+|----------|------|
+| Project page | [civictechdc.org/projects/ballot-initiative](https://www.civictechdc.org/projects/ballot-initiative.html) |
+| Slack channel | [#vote_catcher on CivicTech DC Slack](https://civictechdc.slack.com/archives/C04U3D9AWER) |
+| Code of Conduct | [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) |
+| Security | [SECURITY.md](SECURITY.md) |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -240,8 +240,8 @@ VoteCatcher is a [CivicTech DC](https://www.civictechdc.org/) project. We're bui
 
 | Resource | Link |
 |----------|------|
-| Project page | [civictechdc.org/projects/ballot-initiative](https://www.civictechdc.org/projects/ballot-initiative.html) |
-| Slack channel | [#vote_catcher on CivicTech DC Slack](https://civictechdc.slack.com/archives/C04U3D9AWER) |
+| Project page | https://www.civictechdc.org/projects/ballot-initiative.html |
+| Slack channel | [#vote_catcher](https://civictechdc.slack.com/archives/C04U3D9AWER) |
 | Code of Conduct | [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) |
 | Security | [SECURITY.md](SECURITY.md) |
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,139 @@
+# Security Policy
+
+## Reporting Vulnerabilities
+
+We take security seriously. If you discover a security vulnerability, please report it privately to us via [GitHub Private Vulnerability Reporting](https://github.com/civictechdc/votecatcher/security/advisories/new).
+
+**Do not** disclose vulnerabilities publicly before we have a chance to address them.
+
+### Reporting Process
+
+1. Submit your report through GitHub's Private Vulnerability Reporting
+2. Include details about the vulnerability, reproduction steps, and affected versions
+3. We will acknowledge your report within 7 days when possible
+4. We will work with you to validate and fix the issue
+5. Once a fix is released, we will credit you in the advisory unless you prefer anonymity
+
+## Response Timeline
+
+This is a volunteer-run project, so we cannot provide guaranteed SLAs. We do our best to:
+
+- Acknowledge reports within 7 days when possible
+- Provide an initial assessment within 14 days
+- Release a fix for critical vulnerabilities within 30 days (depending on severity and volunteer availability)
+
+Response times may vary based on severity, volunteer availability, and complexity of the issue.
+
+## Supported Versions
+
+VoteCatcher is currently in pre-1.0 development. Only the latest release receives security updates.
+
+| Version | Supported |
+|---------|-----------|
+| Latest (pre-1.0) | ✅ Yes |
+| All older versions | ❌ No |
+
+**Recommendation:** Always upgrade to the latest release for security fixes.
+
+## Disclosure Policy
+
+We follow coordinated disclosure:
+
+1. Vulnerabilities are fixed before public disclosure
+2. A security advisory is published alongside the fix release
+3. Reporters are credited in the advisory unless they prefer anonymity
+4. Public disclosure happens only after a fix is available
+
+## Security Best Practices for Self-Hosters
+
+If you're self-hosting VoteCatcher, follow these security practices:
+
+### Environment Variables
+
+- **Never commit API keys or secrets** to version control
+- Use environment variables for all sensitive configuration
+- Copy `.env.example` files to `.env` and fill in your values
+- See `backend/.env.example` and `frontend/.env.example` for all required secrets
+
+Required secrets:
+- `DATABASE_URL` — database connection string
+- `BETTER_AUTH_SECRET` — session encryption key
+- `OCR_PROVIDER_API_KEY` — LLM/OCR provider key (unless using simulation mode)
+- `SUPABASE_SERVICE_KEY` — Supabase admin key (if using Supabase)
+
+### Database Security
+
+- **Use PostgreSQL in production**, not SQLite
+- Create a dedicated database user with strong credentials
+- Restrict database access to the application server only
+- Use environment variables for database credentials, not config files
+- Enable SSL for database connections in production
+
+### Supabase (if applicable)
+
+- Use separate anon and service keys
+- Store the service key securely — it has full database access
+- Never expose the service key to client-side code
+- Use Row Level Security (RLS) policies for data access control
+
+### Production Deployment
+
+- **Always use HTTPS** in production
+- Use a reverse proxy (nginx, Caddy) with SSL/TLS termination
+- Keep dependencies updated: `just security-scan`
+- Monitor GitHub Dependabot alerts and code scanning results
+- Review logs regularly for suspicious activity
+
+### Pre-Deployment Checklist
+
+Before deploying to production:
+
+```bash
+# Run security scans
+just security-scan
+
+# Check for known vulnerabilities
+just sca
+```
+
+Verify:
+- [ ] Environment variables are set and not committed
+- [ ] HTTPS is enabled
+- [ ] Database credentials are strong
+- [ ] OCR provider API key is restricted
+- [ ] Dependencies are up to date
+
+## Scope
+
+### In Scope
+
+- Application code in `backend/` and `frontend/`
+- Dependencies (Python and Node.js packages)
+- Authentication and authorization mechanisms
+- Input validation and sanitization
+- API security
+- Database access controls
+- Configuration management
+
+### Out of Scope
+
+- Social engineering attacks
+- Denial of service attacks against self-hosted instances
+- Issues in third-party services (e.g., Supabase, OpenAI)
+- Issues requiring physical access to infrastructure
+- Issues already disclosed publicly (without coordination)
+
+## Security Tools
+
+VoteCatcher uses these security tools:
+
+| Tool | Purpose | Usage |
+|------|---------|-------|
+| `just security-scan` | Run all security scans | Pre-deployment |
+| Dependabot | Automated dependency updates | GitHub integration |
+| GitHub Code Scanning | SAST via CodeQL | CI pipeline |
+| Bandit | Python security linter | CI pipeline |
+| `uv audit` | Python dependency vulnerabilities | CI pipeline |
+| `bun audit` | Node.js dependency vulnerabilities | CI pipeline |
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for CI security checks.


### PR DESCRIPTION
## Summary

Adds community documentation, GitHub issue/PR templates, and security policy to close out the documentation sprint.

## Related Issues

Closes #66
Closes #67
Closes #68
Closes #89

## Changes

### #66 — CODE_OF_CONDUCT.md + CI Auto-Update
- `CODE_OF_CONDUCT.md` synced from [civictechdc/code-of-conduct](https://github.com/civictechdc/code-of-conduct)
- `.github/workflows/sync-coc.yml` — quarterly cron + manual dispatch, opens PR only when upstream changes

### #67 — GitHub Issue Templates + PR Template
- 5 YAML issue forms: bug report, feature request, spike/research, documentation, custom
- `config.yml` — blank issues disabled, contact links to Slack and CONTRIBUTING.md
- `pull_request_template.md` — summary, related issue, change type, testing checklist

### #68 — SECURITY.md
- Reporting via GitHub Private Vulnerability Reporting
- Response timeline (best effort, volunteer project)
- Self-hoster security best practices
- Scope definition
- **Manual step required:** enable secret scanning, push protection, and private vulnerability reporting in repo settings

### #89 — Community Links
- Badge reorder in README: project → tech → community, added Slack badge
- Community section in README with links to project page, Slack, CoC, SECURITY.md
- Expanded "Getting Help" in CONTRIBUTING.md

## Testing

- [x] CODE_OF_CONDUCT.md verified against upstream (content diff only curly/straight quote encoding)
- [x] YAML templates validated (pre-commit check-yaml passed)
- [x] All internal links verified
- [x] Pre-commit hooks pass (secrets scan, yaml check, trailing whitespace)

## Post-Merge Manual Steps

- [x] Enable GitHub security settings: secret scanning, push protection, private vulnerability reporting