### PR TITLE
Pagination cleanup and shared service extraction

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -2,7 +2,7 @@
 name = "cz_conventional_commits"
 tag_format = "v$version"
 version_scheme = "semver"
-version = "1.0.0-alpha.5"
+version = "1.0.0-alpha.6"
 update_changelog_on_bump = false
 major_version_zero = false
 version_files = [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@ Spec-driven voter matching and region selection capabilities were added, includi
 - Updated featureFlags/settings/demo/database tests to use vi.stubEnv.
 
 ### Changed
+- Impl: CSV export batched OCR lookups (#60)
+- Test: CSV batch lookup tests (#53)
 
 - Switched to spec-driven voter list service.
 - Changed production code to spec-only paths.

--- a/backend/alembic/versions/7a5f1e454eac_add_distinct_ocr_count_to_matcher_jobs.py
+++ b/backend/alembic/versions/7a5f1e454eac_add_distinct_ocr_count_to_matcher_jobs.py
@@ -5,6 +5,7 @@ Revises: 25e9ccd8acbe
 Create Date: 2026-04-21 15:12:59.717614
 
 """
+
 from typing import Sequence, Union
 
 from alembic import op
@@ -12,8 +13,8 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision: str = '7a5f1e454eac'
-down_revision: Union[str, Sequence[str], None] = '25e9ccd8acbe'
+revision: str = "7a5f1e454eac"
+down_revision: Union[str, Sequence[str], None] = "25e9ccd8acbe"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/backend/alembic/versions/7a5f1e454eac_add_distinct_ocr_count_to_matcher_jobs.py
+++ b/backend/alembic/versions/7a5f1e454eac_add_distinct_ocr_count_to_matcher_jobs.py
@@ -1,0 +1,29 @@
+"""add_distinct_ocr_count_to_matcher_jobs
+
+Revision ID: 7a5f1e454eac
+Revises: 25e9ccd8acbe
+Create Date: 2026-04-21 15:12:59.717614
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '7a5f1e454eac'
+down_revision: Union[str, Sequence[str], None] = '25e9ccd8acbe'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "matcher_jobs",
+        sa.Column("distinct_ocr_count", sa.Integer(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("matcher_jobs", "distinct_ocr_count")

--- a/backend/app/data/database/model/jobs.py
+++ b/backend/app/data/database/model/jobs.py
@@ -47,6 +47,7 @@ class MatcherJob(SQLModel, table=True):
     error_data: dict = Field(default={}, sa_column=Column(JSON))
     success_data: dict = Field(default={}, sa_column=Column(JSON))
     started_by: int | None = Field(default=None, foreign_key="users.id")
+    distinct_ocr_count: int | None = Field(default=None)
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
 
 

--- a/backend/app/jobs/worker.py
+++ b/backend/app/jobs/worker.py
@@ -264,6 +264,16 @@ class JobWorker:
         previous_status = job.current_status.value if job.current_status else None
         job.current_status = JobStatus.MATCHING_COMPLETED
         job.ended_on = datetime.now(UTC)
+
+        distinct_count = session.exec(
+            select(func.count()).select_from(
+                select(func.distinct(MatchResult.ocr_result_id))
+                .where(MatchResult.matcher_job_id == job.id)
+                .subquery()
+            )
+        ).one()
+        job.distinct_ocr_count = distinct_count
+
         session.commit()
 
         await event_bus.publish(

--- a/backend/app/routers/campaign_router.py
+++ b/backend/app/routers/campaign_router.py
@@ -9,6 +9,7 @@ from pydantic import Field
 from sqlmodel import Session
 
 from app.api_models import ApiModel
+from app.data.database.model.match_result import ConfidenceLevel
 from app.dependencies import get_session
 
 router = APIRouter(prefix="/campaigns", tags=["campaigns"])
@@ -198,7 +199,7 @@ class CampaignMatchPrediction(ApiModel):
     voter_name: str
     voter_address: str
     similarity_score: float
-    confidence: str
+    confidence: ConfidenceLevel
 
 
 class CampaignResultResponse(ApiModel):
@@ -231,7 +232,7 @@ class CampaignResultsListResponse(ApiModel):
 def get_campaign_results(
     campaign_id: uuid.UUID,
     session: SessionDep,
-    confidence: str | None = None,
+    confidence: ConfidenceLevel | None = None,
     cursor: int | None = None,
     page_size: int = 50,
 ) -> CampaignResultsListResponse:

--- a/backend/app/routers/results_router.py
+++ b/backend/app/routers/results_router.py
@@ -24,7 +24,7 @@ class MatchPrediction(ApiModel):
     voter_name: str
     voter_address: str
     similarity_score: float
-    confidence: str
+    confidence: ConfidenceLevel
 
 
 class ResultResponse(ApiModel):

--- a/backend/app/services/campaign_query_service.py
+++ b/backend/app/services/campaign_query_service.py
@@ -70,7 +70,11 @@ class CampaignQueryService:
 
         latest_job = self._session.get(MatcherJob, latest_job_id)
 
-        if confidence is None and latest_job and latest_job.distinct_ocr_count is not None:
+        if (
+            confidence is None
+            and latest_job
+            and latest_job.distinct_ocr_count is not None
+        ):
             total = latest_job.distinct_ocr_count
         else:
             total = self._session.exec(
@@ -123,7 +127,9 @@ class CampaignQueryService:
             extracted_address = ""
             if enrichment and enrichment.raw_extracted_text:
                 extracted_name, extracted_address = (
-                    OcrTextParser.extract_name_and_address(enrichment.raw_extracted_text)
+                    OcrTextParser.extract_name_and_address(
+                        enrichment.raw_extracted_text
+                    )
                 )
 
             predictions = truncate_predictions(predictions_by_ocr.get(ocr_id, []))
@@ -138,8 +144,12 @@ class CampaignQueryService:
                     job_id=job_id,
                     thumbnail_url=enrichment.thumbnail_url if enrichment else "",
                     predictions=predictions,
-                    crop_coordinates=enrichment.crop_coordinates if enrichment else None,
-                    entry_coordinates=enrichment.entry_coordinates if enrichment else None,
+                    crop_coordinates=enrichment.crop_coordinates
+                    if enrichment
+                    else None,
+                    entry_coordinates=enrichment.entry_coordinates
+                    if enrichment
+                    else None,
                     page_number=enrichment.page_number if enrichment else None,
                     document_name=enrichment.document_name if enrichment else "",
                     scan_id=enrichment.scan_id if enrichment else None,

--- a/backend/app/services/campaign_query_service.py
+++ b/backend/app/services/campaign_query_service.py
@@ -22,9 +22,14 @@ from app.routers.campaign_router import (
     SetupStatusResponse,
     VoterListStatus,
 )
-from app.services.entry_coordinates import compute_entry_coordinates
 from app.services.ocr_text_parser import OcrTextParser
 from app.services.prediction_truncation import truncate_predictions
+from app.services.results_shared import (
+    build_predictions,
+    compute_next_cursor,
+    enrich_ocr_lookup,
+    validate_pagination_params,
+)
 
 
 class CampaignQueryService:
@@ -40,14 +45,10 @@ class CampaignQueryService:
         cursor: int | None = None,
         page_size: int = 50,
     ) -> CampaignResultsListResponse:
-        if cursor is not None and cursor < 0:
-            raise ValueError("cursor must be non-negative")
-        if not 1 <= page_size <= 1000:
-            raise ValueError("page_size must be between 1 and 1000")
+        validate_pagination_params(cursor, page_size)
 
         from app.data.database.model.jobs import MatcherJob
         from app.data.database.model.match_result import MatchResult
-        from app.data.database.model.ocr_result import OcrResult
         from app.data.database.model.schema import Campaign
 
         campaign = self._session.get(Campaign, campaign_id)
@@ -107,86 +108,45 @@ class CampaignQueryService:
         ).all()
 
         predictions_by_ocr = self._build_campaign_predictions(page_match_results)
+        enrichment_by_ocr = enrich_ocr_lookup(self._session, paginated_ocr_ids)
 
         job_ids_by_ocr: dict[int, int] = {}
         for result in page_match_results:
             if result.ocr_result_id not in job_ids_by_ocr:
                 job_ids_by_ocr[result.ocr_result_id] = result.matcher_job_id
 
-        ocr_ids_to_fetch = set(paginated_ocr_ids)
-        ocr_results_by_id: dict[int, OcrResult] = {}
-
-        if ocr_ids_to_fetch:
-            ocr_results = self._session.exec(
-                select(OcrResult).where(OcrResult.id.in_(ocr_ids_to_fetch))
-            ).all()
-            ocr_results_by_id = {o.id: o for o in ocr_results}
-
-        crop_ids = {o.crop_id for o in ocr_results_by_id.values() if o.crop_id}
-        crop_by_id: dict = {}
-        scan_by_id: dict = {}
-
-        if crop_ids:
-            from app.data.database.model.petition_crop import PetitionCrop
-
-            crops = self._session.exec(
-                select(PetitionCrop).where(PetitionCrop.id.in_(crop_ids))
-            ).all()
-            crop_by_id = {c.id: c for c in crops}
-
-            scan_ids = {c.scan_id for c in crops if c.scan_id}
-            if scan_ids:
-                from app.data.database.model.petition_scan import PetitionScan
-
-                scans = self._session.exec(
-                    select(PetitionScan).where(PetitionScan.id.in_(scan_ids))
-                ).all()
-                scan_by_id = {s.id: s for s in scans}
-
         results = []
         for ocr_id in paginated_ocr_ids:
-            ocr_result = ocr_results_by_id.get(ocr_id)
+            enrichment = enrichment_by_ocr.get(ocr_id)
 
             extracted_name = ""
             extracted_address = ""
-            crop_id = 0
-            if ocr_result:
+            if enrichment and enrichment.raw_extracted_text:
                 extracted_name, extracted_address = (
-                    OcrTextParser.extract_name_and_address(ocr_result.extracted_text)
+                    OcrTextParser.extract_name_and_address(enrichment.raw_extracted_text)
                 )
-                crop_id = ocr_result.crop_id
 
             predictions = truncate_predictions(predictions_by_ocr.get(ocr_id, []))
             job_id = job_ids_by_ocr.get(ocr_id, 0)
-
-            thumbnail_url = f"/api/crops/{crop_id}/image" if crop_id else ""
-
-            crop = crop_by_id.get(crop_id) if crop_id else None
-            scan = scan_by_id.get(crop.scan_id) if crop and crop.scan_id else None
-            crop_coords = crop.crop_coordinates if crop else None
 
             results.append(
                 CampaignResultResponse(
                     ocr_result_id=ocr_id,
                     extracted_name=extracted_name,
                     extracted_address=extracted_address,
-                    crop_id=crop_id,
+                    crop_id=enrichment.crop_id if enrichment else 0,
                     job_id=job_id,
-                    thumbnail_url=thumbnail_url,
+                    thumbnail_url=enrichment.thumbnail_url if enrichment else "",
                     predictions=predictions,
-                    crop_coordinates=crop_coords,
-                    entry_coordinates=(
-                        compute_entry_coordinates(crop_coords, ocr_result.ocr_index)
-                        if crop_coords and ocr_result
-                        else None
-                    ),
-                    page_number=crop.page_number if crop else None,
-                    document_name=scan.original_filename if scan else "",
-                    scan_id=crop.scan_id if crop else None,
+                    crop_coordinates=enrichment.crop_coordinates if enrichment else None,
+                    entry_coordinates=enrichment.entry_coordinates if enrichment else None,
+                    page_number=enrichment.page_number if enrichment else None,
+                    document_name=enrichment.document_name if enrichment else "",
+                    scan_id=enrichment.scan_id if enrichment else None,
                 )
             )
 
-        next_cursor = None
+        count_after = 0
         if len(paginated_ocr_ids) == page_size:
             last_id = paginated_ocr_ids[-1]
             next_page_where = [
@@ -202,8 +162,8 @@ class CampaignQueryService:
                     .subquery()
                 )
             ).one()
-            if count_after:
-                next_cursor = last_id
+
+        next_cursor = compute_next_cursor(paginated_ocr_ids, page_size, count_after)
 
         return CampaignResultsListResponse(
             results=results,
@@ -216,22 +176,10 @@ class CampaignQueryService:
         self, match_results: list[MatchResult]
     ) -> dict[int, list[CampaignMatchPrediction]]:
         """Build predictions grouped by OCR result ID for campaign results."""
-        from app.data.database.model.registered_voter import RegisteredVoter
-        from app.services.prediction_builder import PredictionBuilder
-
-        voter_ids = {r.voter_id for r in match_results if r.voter_id}
-        voters_by_id: dict[int, RegisteredVoter] = {}
-
-        if voter_ids:
-            voters = self._session.exec(
-                select(RegisteredVoter).where(RegisteredVoter.id.in_(voter_ids))
-            ).all()
-            voters_by_id = {v.id: v for v in voters}
-
-        raw_predictions = PredictionBuilder.build(match_results, voters_by_id)
+        raw = build_predictions(self._session, match_results)
 
         predictions_by_ocr: dict[int, list[CampaignMatchPrediction]] = {}
-        for ocr_id, preds in raw_predictions.items():
+        for ocr_id, preds in raw.items():
             predictions_by_ocr[ocr_id] = [
                 CampaignMatchPrediction(
                     rank=p.rank,

--- a/backend/app/services/campaign_query_service.py
+++ b/backend/app/services/campaign_query_service.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
 
 from sqlalchemy import func
 
+from app.data.database.model.match_result import ConfidenceLevel
 from app.routers.campaign_router import (
     CampaignMatchPrediction,
     CampaignResultResponse,
@@ -35,7 +36,7 @@ class CampaignQueryService:
     def get_campaign_results(
         self,
         campaign_id: uuid.UUID,
-        confidence: str | None = None,
+        confidence: ConfidenceLevel | None = None,
         cursor: int | None = None,
         page_size: int = 50,
     ) -> CampaignResultsListResponse:
@@ -45,7 +46,7 @@ class CampaignQueryService:
             raise ValueError("page_size must be between 1 and 1000")
 
         from app.data.database.model.jobs import MatcherJob
-        from app.data.database.model.match_result import ConfidenceLevel, MatchResult
+        from app.data.database.model.match_result import MatchResult
         from app.data.database.model.ocr_result import OcrResult
         from app.data.database.model.schema import Campaign
 
@@ -62,19 +63,9 @@ class CampaignQueryService:
                 results=[], total=0, page_size=page_size, next_cursor=None
             )
 
-        confidence_filter = None
-        if confidence:
-            try:
-                confidence_filter = ConfidenceLevel(confidence.upper())
-            except ValueError:
-                raise ValueError(
-                    f"Invalid confidence level: {confidence!r}. "
-                    f"Must be one of: {[e.value for e in ConfidenceLevel]}"
-                )
-
         base_where = [MatchResult.matcher_job_id == latest_job_id]
-        if confidence_filter:
-            base_where.append(MatchResult.confidence_level == confidence_filter)
+        if confidence:
+            base_where.append(MatchResult.confidence_level == confidence)
 
         total = self._session.exec(
             select(func.count()).select_from(
@@ -197,10 +188,8 @@ class CampaignQueryService:
                 MatchResult.matcher_job_id == latest_job_id,
                 MatchResult.ocr_result_id > last_id,
             ]
-            if confidence_filter:
-                next_page_where.append(
-                    MatchResult.confidence_level == confidence_filter
-                )
+            if confidence:
+                next_page_where.append(MatchResult.confidence_level == confidence)
             count_after = self._session.exec(
                 select(func.count()).select_from(
                     select(func.distinct(MatchResult.ocr_result_id))

--- a/backend/app/services/campaign_query_service.py
+++ b/backend/app/services/campaign_query_service.py
@@ -67,13 +67,18 @@ class CampaignQueryService:
         if confidence:
             base_where.append(MatchResult.confidence_level == confidence)
 
-        total = self._session.exec(
-            select(func.count()).select_from(
-                select(func.distinct(MatchResult.ocr_result_id))
-                .where(*base_where)
-                .subquery()
-            )
-        ).one()
+        latest_job = self._session.get(MatcherJob, latest_job_id)
+
+        if confidence is None and latest_job and latest_job.distinct_ocr_count is not None:
+            total = latest_job.distinct_ocr_count
+        else:
+            total = self._session.exec(
+                select(func.count()).select_from(
+                    select(func.distinct(MatchResult.ocr_result_id))
+                    .where(*base_where)
+                    .subquery()
+                )
+            ).one()
 
         if total == 0:
             return CampaignResultsListResponse(

--- a/backend/app/services/prediction_builder.py
+++ b/backend/app/services/prediction_builder.py
@@ -9,6 +9,8 @@ if TYPE_CHECKING:
     from app.data.database.model.match_result import MatchResult
     from app.data.database.model.registered_voter import RegisteredVoter
 
+from app.data.database.model.match_result import ConfidenceLevel
+
 
 @dataclass(frozen=True)
 class PredictionData:
@@ -16,7 +18,7 @@ class PredictionData:
     voter_name: str
     voter_address: str
     similarity_score: float
-    confidence: str
+    confidence: ConfidenceLevel
 
 
 class PredictionBuilder:
@@ -78,9 +80,9 @@ class PredictionBuilder:
                     if voter
                     else "",
                     similarity_score=result.similarity_score,
-                    confidence=result.confidence_level.value
+                    confidence=result.confidence_level
                     if result.confidence_level
-                    else "LOW",
+                    else ConfidenceLevel.LOW,
                 )
             )
 

--- a/backend/app/services/results_query_service.py
+++ b/backend/app/services/results_query_service.py
@@ -8,9 +8,14 @@ from typing import TYPE_CHECKING, Optional
 from sqlmodel import Session, select
 
 from sqlalchemy import func
-from app.services.entry_coordinates import compute_entry_coordinates
 from app.services.ocr_text_parser import OcrTextParser
 from app.services.prediction_truncation import truncate_predictions
+from app.services.results_shared import (
+    build_predictions,
+    compute_next_cursor,
+    enrich_ocr_lookup,
+    validate_pagination_params,
+)
 
 if TYPE_CHECKING:
     from app.data.database.model.match_result import ConfidenceLevel, MatchResult
@@ -40,15 +45,15 @@ class ResultsQueryService:
         cursor: Optional[int] = None,
         page_size: int = 50,
     ) -> "ResultsListResponse":
-        if cursor is not None and cursor < 0:
-            raise ValueError("cursor must be non-negative")
-        if not 1 <= page_size <= 1000:
-            raise ValueError("page_size must be between 1 and 1000")
+        validate_pagination_params(cursor, page_size)
 
         from app.data.database.model.jobs import MatcherJob
         from app.data.database.model.match_result import MatchResult
-        from app.data.database.model.ocr_result import OcrResult
-        from app.routers.results_router import ResultResponse, ResultsListResponse
+        from app.routers.results_router import (
+            MatchPrediction,
+            ResultResponse,
+            ResultsListResponse,
+        )
 
         job = self._session.get(MatcherJob, job_id)
         if not job:
@@ -70,19 +75,18 @@ class ResultsQueryService:
             ).one()
 
         if total == 0:
-            from app.routers.results_router import ResultsListResponse
-
             return ResultsListResponse(
                 results=[], total=0, page_size=page_size, next_cursor=None
             )
 
+        cursor_where = list(base_where)
         if cursor is not None and cursor > 0:
-            base_where.append(MatchResult.ocr_result_id > cursor)
+            cursor_where.append(MatchResult.ocr_result_id > cursor)
 
         paginated_ocr_ids = list(
             self._session.exec(
                 select(MatchResult.ocr_result_id)
-                .where(*base_where)
+                .where(*cursor_where)
                 .distinct()
                 .order_by(MatchResult.ocr_result_id)
                 .limit(page_size)
@@ -96,78 +100,40 @@ class ResultsQueryService:
             )
         ).all()
 
-        predictions_by_ocr = self._build_predictions_from_match_results(
-            page_match_results
-        )
-
-        ocr_ids_to_fetch = {r.ocr_result_id for r in page_match_results}
-        ocr_results_by_id: dict[int, OcrResult] = {}
-
-        if ocr_ids_to_fetch:
-            ocr_results = self._session.exec(
-                select(OcrResult).where(OcrResult.id.in_(ocr_ids_to_fetch))
-            ).all()
-            ocr_results_by_id = {o.id: o for o in ocr_results}
-
-        crop_ids = {o.crop_id for o in ocr_results_by_id.values() if o.crop_id}
-        crop_by_id: dict[int, "PetitionCrop"] = {}
-        scan_by_id: dict[int, "PetitionScan"] = {}
-
-        if crop_ids:
-            from app.data.database.model.petition_crop import PetitionCrop
-
-            crops = self._session.exec(
-                select(PetitionCrop).where(PetitionCrop.id.in_(crop_ids))
-            ).all()
-            crop_by_id = {c.id: c for c in crops}
-
-            scan_ids = {c.scan_id for c in crops}
-            if scan_ids:
-                from app.data.database.model.petition_scan import PetitionScan
-
-                scans = self._session.exec(
-                    select(PetitionScan).where(PetitionScan.id.in_(scan_ids))
-                ).all()
-                scan_by_id = {s.id: s for s in scans}
+        predictions_by_ocr = build_predictions(self._session, page_match_results)
+        enrichment_by_ocr = enrich_ocr_lookup(self._session, paginated_ocr_ids)
 
         results = []
         for ocr_id in paginated_ocr_ids:
-            ocr_result = ocr_results_by_id.get(ocr_id)
-
-            extracted_text = (
-                OcrTextParser.format_text(ocr_result.extracted_text)
-                if ocr_result
-                else ""
-            )
-            crop_id = ocr_result.crop_id if ocr_result else 0
-            thumbnail_url = f"/api/crops/{crop_id}/image" if crop_id else ""
-
-            crop = crop_by_id.get(crop_id) if crop_id else None
-            scan = scan_by_id.get(crop.scan_id) if crop else None
-            crop_coords = crop.crop_coordinates if crop else None
-
-            predictions = truncate_predictions(predictions_by_ocr.get(ocr_id, []))
+            enrichment = enrichment_by_ocr.get(ocr_id)
+            raw_preds = truncate_predictions(predictions_by_ocr.get(ocr_id, []))
+            predictions = [
+                MatchPrediction(
+                    rank=p.rank,
+                    voter_name=p.voter_name,
+                    voter_address=p.voter_address,
+                    similarity_score=p.similarity_score,
+                    confidence=p.confidence,
+                )
+                for p in raw_preds
+            ]
 
             results.append(
                 ResultResponse(
                     ocr_result_id=ocr_id,
-                    extracted_text=extracted_text,
-                    crop_id=crop_id,
-                    thumbnail_url=thumbnail_url,
+                    extracted_text=enrichment.extracted_text if enrichment else "",
+                    crop_id=enrichment.crop_id if enrichment else 0,
+                    thumbnail_url=enrichment.thumbnail_url if enrichment else "",
                     predictions=predictions,
-                    crop_coordinates=crop_coords,
-                    entry_coordinates=(
-                        compute_entry_coordinates(crop_coords, ocr_result.ocr_index)
-                        if crop_coords and ocr_result
-                        else None
-                    ),
-                    page_number=crop.page_number if crop else None,
-                    document_name=scan.original_filename if scan else "",
-                    scan_id=crop.scan_id if crop else None,
+                    crop_coordinates=enrichment.crop_coordinates if enrichment else None,
+                    entry_coordinates=enrichment.entry_coordinates if enrichment else None,
+                    page_number=enrichment.page_number if enrichment else None,
+                    document_name=enrichment.document_name if enrichment else "",
+                    scan_id=enrichment.scan_id if enrichment else None,
                 )
             )
 
-        next_cursor = None
+        count_after = 0
         if len(paginated_ocr_ids) == page_size:
             last_id = paginated_ocr_ids[-1]
             next_page_where = list(base_where) + [MatchResult.ocr_result_id > last_id]
@@ -178,8 +144,8 @@ class ResultsQueryService:
                     .subquery()
                 )
             ).one()
-            if count_after:
-                next_cursor = last_id
+
+        next_cursor = compute_next_cursor(paginated_ocr_ids, page_size, count_after)
 
         return ResultsListResponse(
             results=results,
@@ -191,31 +157,13 @@ class ResultsQueryService:
     def _build_predictions_from_match_results(
         self, match_results: list["MatchResult"]
     ) -> dict[int, list["MatchPrediction"]]:
-        """Build predictions grouped by OCR result ID.
-
-        Args:
-            match_results: List of MatchResult records
-
-        Returns:
-            Dict mapping ocr_result_id to list of predictions
-        """
-        from app.data.database.model.registered_voter import RegisteredVoter
+        """Build predictions grouped by OCR result ID."""
         from app.routers.results_router import MatchPrediction
-        from app.services.prediction_builder import PredictionBuilder
 
-        voter_ids = {r.voter_id for r in match_results if r.voter_id}
-        voters_by_id: dict[int, RegisteredVoter] = {}
-
-        if voter_ids:
-            voters = self._session.exec(
-                select(RegisteredVoter).where(RegisteredVoter.id.in_(voter_ids))
-            ).all()
-            voters_by_id = {v.id: v for v in voters}
-
-        raw_predictions = PredictionBuilder.build(match_results, voters_by_id)
+        raw = build_predictions(self._session, match_results)
 
         predictions_by_ocr: dict[int, list[MatchPrediction]] = {}
-        for ocr_id, preds in raw_predictions.items():
+        for ocr_id, preds in raw.items():
             predictions_by_ocr[ocr_id] = [
                 MatchPrediction(
                     rank=p.rank,

--- a/backend/app/services/results_query_service.py
+++ b/backend/app/services/results_query_service.py
@@ -58,13 +58,16 @@ class ResultsQueryService:
         if confidence:
             base_where.append(MatchResult.confidence_level == confidence)
 
-        total = self._session.exec(
-            select(func.count()).select_from(
-                select(func.distinct(MatchResult.ocr_result_id))
-                .where(*base_where)
-                .subquery()
-            )
-        ).one()
+        if confidence is None and job.distinct_ocr_count is not None:
+            total = job.distinct_ocr_count
+        else:
+            total = self._session.exec(
+                select(func.count()).select_from(
+                    select(func.distinct(MatchResult.ocr_result_id))
+                    .where(*base_where)
+                    .subquery()
+                )
+            ).one()
 
         if total == 0:
             from app.routers.results_router import ResultsListResponse

--- a/backend/app/services/results_query_service.py
+++ b/backend/app/services/results_query_service.py
@@ -125,8 +125,12 @@ class ResultsQueryService:
                     crop_id=enrichment.crop_id if enrichment else 0,
                     thumbnail_url=enrichment.thumbnail_url if enrichment else "",
                     predictions=predictions,
-                    crop_coordinates=enrichment.crop_coordinates if enrichment else None,
-                    entry_coordinates=enrichment.entry_coordinates if enrichment else None,
+                    crop_coordinates=enrichment.crop_coordinates
+                    if enrichment
+                    else None,
+                    entry_coordinates=enrichment.entry_coordinates
+                    if enrichment
+                    else None,
                     page_number=enrichment.page_number if enrichment else None,
                     document_name=enrichment.document_name if enrichment else "",
                     scan_id=enrichment.scan_id if enrichment else None,

--- a/backend/app/services/results_shared.py
+++ b/backend/app/services/results_shared.py
@@ -1,0 +1,165 @@
+"""Shared helpers for results query services.
+
+Eliminates duplication between ResultsQueryService and CampaignQueryService.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from sqlmodel import select
+
+from app.services.prediction_builder import PredictionBuilder
+
+if TYPE_CHECKING:
+    from sqlmodel import Session
+
+    from app.data.database.model.match_result import ConfidenceLevel, MatchResult
+
+
+MIN_PAGE_SIZE = 1
+MAX_PAGE_SIZE = 1000
+
+
+@dataclass(frozen=True)
+class PredictionView:
+    rank: int
+    voter_name: str
+    voter_address: str
+    similarity_score: float
+    confidence: "ConfidenceLevel"
+
+
+@dataclass(frozen=True)
+class OcrEnrichment:
+    crop_id: int
+    thumbnail_url: str
+    crop_coordinates: dict[str, float] | None
+    entry_coordinates: dict[str, float] | None
+    page_number: int | None
+    document_name: str
+    scan_id: int | None
+    extracted_text: str
+    raw_extracted_text: dict | None = None
+
+
+def validate_pagination_params(
+    cursor: int | None, page_size: int
+) -> None:
+    if cursor is not None and cursor < 0:
+        raise ValueError("cursor must be non-negative")
+    if not MIN_PAGE_SIZE <= page_size <= MAX_PAGE_SIZE:
+        raise ValueError(
+            f"page_size must be between {MIN_PAGE_SIZE} and {MAX_PAGE_SIZE}"
+        )
+
+
+def build_predictions(
+    session: "Session",
+    match_results: list["MatchResult"],
+) -> dict[int, list[PredictionView]]:
+    from app.data.database.model.registered_voter import RegisteredVoter
+
+    voter_ids = {r.voter_id for r in match_results if r.voter_id}
+    voters_by_id: dict[int, RegisteredVoter] = {}
+
+    if voter_ids:
+        voters = session.exec(
+            select(RegisteredVoter).where(RegisteredVoter.id.in_(voter_ids))
+        ).all()
+        voters_by_id = {v.id: v for v in voters}
+
+    raw = PredictionBuilder.build(match_results, voters_by_id)
+
+    predictions_by_ocr: dict[int, list[PredictionView]] = {}
+    for ocr_id, preds in raw.items():
+        predictions_by_ocr[ocr_id] = [
+            PredictionView(
+                rank=p.rank,
+                voter_name=p.voter_name,
+                voter_address=p.voter_address,
+                similarity_score=p.similarity_score,
+                confidence=p.confidence,
+            )
+            for p in preds
+        ]
+
+    return predictions_by_ocr
+
+
+def enrich_ocr_lookup(
+    session: "Session",
+    ocr_ids: list[int],
+) -> dict[int, OcrEnrichment]:
+    from app.data.database.model.ocr_result import OcrResult
+    from app.data.database.model.petition_crop import PetitionCrop
+    from app.data.database.model.petition_scan import PetitionScan
+    from app.services.entry_coordinates import compute_entry_coordinates
+    from app.services.ocr_text_parser import OcrTextParser
+
+    if not ocr_ids:
+        return {}
+
+    ocr_results = session.exec(
+        select(OcrResult).where(OcrResult.id.in_(ocr_ids))
+    ).all()
+    ocr_by_id = {o.id: o for o in ocr_results}
+
+    crop_ids = {o.crop_id for o in ocr_results if o.crop_id}
+    crop_by_id: dict[int, Any] = {}
+    scan_by_id: dict[int, Any] = {}
+
+    if crop_ids:
+        crops = session.exec(
+            select(PetitionCrop).where(PetitionCrop.id.in_(crop_ids))
+        ).all()
+        crop_by_id = {c.id: c for c in crops}
+
+        scan_ids = {c.scan_id for c in crops if c.scan_id}
+        if scan_ids:
+            scans = session.exec(
+                select(PetitionScan).where(PetitionScan.id.in_(scan_ids))
+            ).all()
+            scan_by_id = {s.id: s for s in scans}
+
+    result: dict[int, OcrEnrichment] = {}
+    for ocr_id in ocr_ids:
+        ocr = ocr_by_id.get(ocr_id)
+        extracted_text = (
+            OcrTextParser.format_text(ocr.extracted_text) if ocr else ""
+        )
+        crop_id = ocr.crop_id if ocr else 0
+        thumbnail_url = f"/api/crops/{crop_id}/image" if crop_id else ""
+
+        crop = crop_by_id.get(crop_id) if crop_id else None
+        scan = scan_by_id.get(crop.scan_id) if crop and crop.scan_id else None
+        crop_coords = crop.crop_coordinates if crop else None
+
+        result[ocr_id] = OcrEnrichment(
+            crop_id=crop_id,
+            thumbnail_url=thumbnail_url,
+            crop_coordinates=crop_coords,
+            entry_coordinates=(
+                compute_entry_coordinates(crop_coords, ocr.ocr_index)
+                if crop_coords and ocr
+                else None
+            ),
+            page_number=crop.page_number if crop else None,
+            document_name=scan.original_filename if scan else "",
+            scan_id=crop.scan_id if crop else None,
+            extracted_text=extracted_text,
+            raw_extracted_text=ocr.extracted_text if ocr else None,
+        )
+
+    return result
+
+
+def compute_next_cursor(
+    paginated_ids: list[int],
+    page_size: int,
+    count_after: int,
+) -> int | None:
+    if len(paginated_ids) == page_size and count_after > 0:
+        return paginated_ids[-1]
+    return None

--- a/backend/app/services/results_shared.py
+++ b/backend/app/services/results_shared.py
@@ -44,9 +44,7 @@ class OcrEnrichment:
     raw_extracted_text: dict | None = None
 
 
-def validate_pagination_params(
-    cursor: int | None, page_size: int
-) -> None:
+def validate_pagination_params(cursor: int | None, page_size: int) -> None:
     if cursor is not None and cursor < 0:
         raise ValueError("cursor must be non-negative")
     if not MIN_PAGE_SIZE <= page_size <= MAX_PAGE_SIZE:
@@ -101,9 +99,7 @@ def enrich_ocr_lookup(
     if not ocr_ids:
         return {}
 
-    ocr_results = session.exec(
-        select(OcrResult).where(OcrResult.id.in_(ocr_ids))
-    ).all()
+    ocr_results = session.exec(select(OcrResult).where(OcrResult.id.in_(ocr_ids))).all()
     ocr_by_id = {o.id: o for o in ocr_results}
 
     crop_ids = {o.crop_id for o in ocr_results if o.crop_id}
@@ -126,9 +122,7 @@ def enrich_ocr_lookup(
     result: dict[int, OcrEnrichment] = {}
     for ocr_id in ocr_ids:
         ocr = ocr_by_id.get(ocr_id)
-        extracted_text = (
-            OcrTextParser.format_text(ocr.extracted_text) if ocr else ""
-        )
+        extracted_text = OcrTextParser.format_text(ocr.extracted_text) if ocr else ""
         crop_id = ocr.crop_id if ocr else 0
         thumbnail_url = f"/api/crops/{crop_id}/image" if crop_id else ""
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ballot-petition-signature-verifier"
-version = "1.0.0-alpha.5"
+version = "1.0.0-alpha.6"
 description = "A python package for verifying ballot petition signatures"
 readme = "README.md"
 requires-python = ">=3.12,<4"

--- a/backend/tests/integration/api/test_campaign_results.py
+++ b/backend/tests/integration/api/test_campaign_results.py
@@ -403,3 +403,20 @@ class TestCampaignResultsAPI:
         assert prediction["confidence"] == "HIGH"
         assert prediction["similarityScore"] == 1.0
         assert result["jobId"] == new_job.id
+
+    def test_invalid_confidence_returns_422(
+        self,
+        client: TestClient,
+        test_campaign: Campaign,
+    ):
+        """Should return 422 for invalid confidence value, not 404.
+
+        Regression guard: confidence parameter typed as ConfidenceLevel enum,
+        so FastAPI validates before the service layer sees bad input.
+        """
+        response = client.get(
+            f"/api/campaigns/{test_campaign.id}/results",
+            params={"confidence": "INVALID"},
+        )
+
+        assert response.status_code == 422

--- a/backend/tests/security/test_sql_injection.py
+++ b/backend/tests/security/test_sql_injection.py
@@ -27,12 +27,12 @@ class TestSQLInjection:
     def test_campaign_results_safe_with_special_chars(
         self, client: TestClient, test_campaign: Campaign
     ):
-        """Should handle special characters in query parameters safely."""
+        """Should reject invalid confidence values (typed enum rejects injection strings)."""
         response = client.get(
             f"/api/campaigns/{test_campaign.id}/results?confidence=HIGH' OR '1'='1"
         )
 
-        assert response.status_code in [200, 404]
+        assert response.status_code == 422
 
     def test_list_campaigns_with_negative_offset(self, client: TestClient):
         """Should handle negative offset gracefully."""

--- a/backend/tests/unit/services/test_campaign_query_service.py
+++ b/backend/tests/unit/services/test_campaign_query_service.py
@@ -289,7 +289,9 @@ class TestGetCampaignResults:
         session.commit()
 
         service = CampaignQueryService(session)
-        result = service.get_campaign_results(campaign.id, confidence="HIGH")
+        result = service.get_campaign_results(
+            campaign.id, confidence=ConfidenceLevel.HIGH
+        )
 
         assert result.total == 2
         for r in result.results:

--- a/backend/tests/unit/services/test_cursor_pagination.py
+++ b/backend/tests/unit/services/test_cursor_pagination.py
@@ -530,3 +530,134 @@ class TestAdversarialFindings:
         assert result.total == 2
         assert len(result.results) == 2
         assert result.next_cursor is None
+
+
+class TestCachedTotalCount:
+    """Feature: Cached total count in job metadata.
+
+    As the system
+    I want to cache the distinct OCR count on job completion
+    So that pagination queries skip the expensive COUNT(DISTINCT) query.
+    """
+
+    def test_cached_count_used_as_total(self, session):
+        """Scenario: Job with distinct_ocr_count set skips COUNT query."""
+        from app.services.results_query_service import ResultsQueryService
+
+        region = _seed_region(session)
+        campaign = _seed_campaign(session, region)
+        scan = _seed_scan(session, campaign)
+        job = _seed_job(session, campaign)
+        _build_ocr_chain(session, job, scan, 5)
+
+        job.distinct_ocr_count = 42
+        session.add(job)
+        session.commit()
+
+        service = ResultsQueryService(session)
+        result = service.get_results(job.id, cursor=None, page_size=3)
+
+        assert result.total == 42
+
+    def test_uncached_job_runs_count_query(self, session):
+        """Scenario: Job without distinct_ocr_count falls back to COUNT query."""
+        from app.services.results_query_service import ResultsQueryService
+
+        region = _seed_region(session)
+        campaign = _seed_campaign(session, region)
+        scan = _seed_scan(session, campaign)
+        job = _seed_job(session, campaign)
+        _build_ocr_chain(session, job, scan, 7)
+
+        service = ResultsQueryService(session)
+        result = service.get_results(job.id, cursor=None, page_size=3)
+
+        assert result.total == 7
+
+    def test_campaign_uses_cached_count(self, session):
+        """Scenario: Campaign endpoint uses cached count from latest job."""
+        from app.services.campaign_query_service import CampaignQueryService
+
+        region = _seed_region(session)
+        campaign = _seed_campaign(session, region)
+        scan = _seed_scan(session, campaign)
+        job = _seed_job(session, campaign)
+        _build_ocr_chain(session, job, scan, 5)
+
+        job.distinct_ocr_count = 99
+        session.add(job)
+        session.commit()
+
+        service = CampaignQueryService(session)
+        result = service.get_campaign_results(campaign.id, cursor=None, page_size=3)
+
+        assert result.total == 99
+
+    def test_campaign_uncached_runs_count(self, session):
+        """Scenario: Campaign endpoint without cache runs COUNT query."""
+        from app.services.campaign_query_service import CampaignQueryService
+
+        region = _seed_region(session)
+        campaign = _seed_campaign(session, region)
+        scan = _seed_scan(session, campaign)
+        job = _seed_job(session, campaign)
+        _build_ocr_chain(session, job, scan, 3)
+
+        service = CampaignQueryService(session)
+        result = service.get_campaign_results(campaign.id, cursor=None, page_size=10)
+
+        assert result.total == 3
+
+    def test_cached_count_with_confidence_filter_ignored(self, session):
+        """Scenario: Cached count ignored when confidence filter applied.
+
+        Cached count is total unfiltered. Confidence-filtered queries
+        must still run COUNT to get the filtered total.
+        """
+        from app.services.results_query_service import ResultsQueryService
+
+        region = _seed_region(session)
+        campaign = _seed_campaign(session, region)
+        scan = _seed_scan(session, campaign)
+        job = _seed_job(session, campaign)
+
+        for i in range(4):
+            crop = PetitionCrop(
+                scan_id=scan.id,
+                crop_index=i,
+                stored_path=f"/tmp/crop_{i}.png",
+                crop_coordinates={"top": 0.0, "bottom": 0.1},
+                page_number=1,
+            )
+            session.add(crop)
+            session.flush()
+            ocr = OcrResult(
+                crop_id=crop.id,
+                ocr_job_id=1,
+                extracted_text={"name": f"Sig {i}"},
+            )
+            session.add(ocr)
+            session.flush()
+            level = ConfidenceLevel.HIGH if i < 2 else ConfidenceLevel.LOW
+            session.add(
+                MatchResult(
+                    matcher_job_id=job.id,
+                    ocr_result_id=ocr.id,
+                    voter_id=None,
+                    rank=1,
+                    similarity_score=0.85,
+                    confidence_level=level,
+                )
+            )
+        session.commit()
+
+        job.distinct_ocr_count = 4
+        session.add(job)
+        session.commit()
+
+        service = ResultsQueryService(session)
+        result = service.get_results(
+            job.id, cursor=None, page_size=10, confidence=ConfidenceLevel.HIGH
+        )
+
+        assert result.total == 2

--- a/backend/tests/unit/services/test_cursor_pagination.py
+++ b/backend/tests/unit/services/test_cursor_pagination.py
@@ -406,8 +406,9 @@ class TestAdversarialFindings:
         with pytest.raises(ValueError, match="page_size must be between"):
             service.get_results(job.id, page_size=0)
 
-    def test_campaign_invalid_confidence_rejected(self, session):
-        """Scenario: Invalid confidence string raises ValueError, not silently ignored."""
+    def test_campaign_confidence_filter_with_enum(self, session):
+        """Scenario: Confidence filter accepts ConfidenceLevel enum values."""
+        from app.data.database.model.match_result import ConfidenceLevel
         from app.services.campaign_query_service import CampaignQueryService
 
         region = _seed_region(session)
@@ -417,8 +418,11 @@ class TestAdversarialFindings:
         _build_ocr_chain(session, job, scan, 5)
 
         service = CampaignQueryService(session)
-        with pytest.raises(ValueError, match="Invalid confidence"):
-            service.get_campaign_results(campaign.id, confidence="INVALID", page_size=3)
+        result = service.get_campaign_results(
+            campaign.id, confidence=ConfidenceLevel.HIGH, page_size=3
+        )
+        for r in result.results:
+            assert r.predictions[0].confidence == "HIGH"
 
     def test_campaign_uses_latest_job_only(self, session):
         """Scenario: Campaign results reflect only the latest (max ID) job, not all jobs."""

--- a/backend/tests/unit/services/test_results_shared.py
+++ b/backend/tests/unit/services/test_results_shared.py
@@ -19,9 +19,7 @@ from app.data.database.model.schema import Campaign, Region
 
 
 def _seed_region(session: Session) -> Region:
-    region = Region(
-        region_key="DC", region_name="Washington, DC", country_code="US"
-    )
+    region = Region(region_key="DC", region_name="Washington, DC", country_code="US")
     session.add(region)
     session.flush()
     return region
@@ -137,7 +135,12 @@ class TestBuildPredictions:
         voter = RegisteredVoter(
             region_id=region.id,
             name_data={"first_name": "Alice", "last_name": "Smith"},
-            address_data={"street": "1 Oak St", "city": "DC", "state": "DC", "zip": "20001"},
+            address_data={
+                "street": "1 Oak St",
+                "city": "DC",
+                "state": "DC",
+                "zip": "20001",
+            },
             data_hash="h1",
         )
         session.add(voter)

--- a/backend/tests/unit/services/test_results_shared.py
+++ b/backend/tests/unit/services/test_results_shared.py
@@ -1,0 +1,307 @@
+"""BDD tests for shared results helpers module.
+
+RED phase: Tests reference app.services.results_shared which does not exist yet.
+All tests must FAIL until the shared module is created.
+"""
+
+import uuid
+
+import pytest
+from sqlmodel import Session
+
+from app.data.database.model.jobs import JobStatus, MatcherJob
+from app.data.database.model.match_result import ConfidenceLevel, MatchResult
+from app.data.database.model.ocr_result import OcrResult
+from app.data.database.model.petition_crop import PetitionCrop
+from app.data.database.model.petition_scan import PetitionScan
+from app.data.database.model.registered_voter import RegisteredVoter
+from app.data.database.model.schema import Campaign, Region
+
+
+def _seed_region(session: Session) -> Region:
+    region = Region(
+        region_key="DC", region_name="Washington, DC", country_code="US"
+    )
+    session.add(region)
+    session.flush()
+    return region
+
+
+def _seed_campaign(session: Session, region: Region) -> Campaign:
+    campaign = Campaign(
+        unique_name=f"shared-test-{uuid.uuid4().hex[:8]}",
+        title="Shared Test",
+        year="2024",
+        region_id=region.id,
+    )
+    session.add(campaign)
+    session.flush()
+    return campaign
+
+
+def _seed_scan(session: Session, campaign: Campaign) -> PetitionScan:
+    scan = PetitionScan(
+        campaign_id=campaign.id,
+        original_filename="test.pdf",
+        stored_path="/tmp/test.pdf",
+        file_hash="abc123",
+        page_count=1,
+    )
+    session.add(scan)
+    session.flush()
+    return scan
+
+
+def _seed_crop(session: Session, scan: PetitionScan, index: int = 0) -> PetitionCrop:
+    crop = PetitionCrop(
+        scan_id=scan.id,
+        crop_index=index,
+        stored_path=f"/tmp/crop_{index}.png",
+        crop_coordinates={"top": 0.0, "bottom": 0.1},
+        page_number=1,
+    )
+    session.add(crop)
+    session.flush()
+    return crop
+
+
+def _seed_job(session: Session, campaign: Campaign) -> MatcherJob:
+    job = MatcherJob(
+        campaign_id=campaign.id,
+        current_status=JobStatus.MATCHING_COMPLETED,
+    )
+    session.add(job)
+    session.flush()
+    return job
+
+
+class TestValidatePaginationParams:
+    """Feature: Pagination parameter validation.
+
+    As the results service
+    I want shared validation for cursor and page_size
+    So that both job and campaign endpoints enforce the same constraints.
+    """
+
+    def test_negative_cursor_raises(self):
+        """Scenario: Negative cursor raises ValueError."""
+        from app.services.results_shared import validate_pagination_params
+
+        with pytest.raises(ValueError, match="cursor must be non-negative"):
+            validate_pagination_params(cursor=-1, page_size=50)
+
+    def test_page_size_zero_raises(self):
+        """Scenario: page_size=0 raises ValueError."""
+        from app.services.results_shared import validate_pagination_params
+
+        with pytest.raises(ValueError, match="page_size must be between"):
+            validate_pagination_params(cursor=None, page_size=0)
+
+    def test_page_size_above_max_raises(self):
+        """Scenario: page_size > 1000 raises ValueError."""
+        from app.services.results_shared import validate_pagination_params
+
+        with pytest.raises(ValueError, match="page_size must be between"):
+            validate_pagination_params(cursor=None, page_size=10001)
+
+    def test_valid_params_pass(self):
+        """Scenario: Valid cursor and page_size do not raise."""
+        from app.services.results_shared import validate_pagination_params
+
+        validate_pagination_params(cursor=None, page_size=50)
+        validate_pagination_params(cursor=100, page_size=1)
+        validate_pagination_params(cursor=0, page_size=1000)
+
+
+class TestBuildPredictions:
+    """Feature: Shared prediction building.
+
+    As both query services
+    I want a single function to build predictions from match results
+    So that prediction construction is identical across endpoints.
+    """
+
+    def test_empty_match_results_returns_empty(self, session: Session):
+        """Scenario: No match results yields empty dict."""
+        from app.services.results_shared import build_predictions
+
+        result = build_predictions(session, [])
+
+        assert result == {}
+
+    def test_predictions_with_voter_data(self, session: Session):
+        """Scenario: Match result with voter builds named prediction."""
+        from app.services.results_shared import build_predictions
+
+        region = _seed_region(session)
+        voter = RegisteredVoter(
+            region_id=region.id,
+            name_data={"first_name": "Alice", "last_name": "Smith"},
+            address_data={"street": "1 Oak St", "city": "DC", "state": "DC", "zip": "20001"},
+            data_hash="h1",
+        )
+        session.add(voter)
+        session.flush()
+
+        match = MatchResult(
+            matcher_job_id=1,
+            ocr_result_id=10,
+            voter_id=voter.id,
+            rank=1,
+            similarity_score=0.95,
+            confidence_level=ConfidenceLevel.HIGH,
+        )
+        session.add(match)
+        session.commit()
+
+        result = build_predictions(session, [match])
+
+        assert 10 in result
+        assert len(result[10]) == 1
+        assert result[10][0].rank == 1
+        assert result[10][0].voter_name == "Alice Smith"
+        assert result[10][0].confidence == ConfidenceLevel.HIGH
+
+    def test_predictions_without_voter(self, session: Session):
+        """Scenario: Match result with no voter_id yields empty name/address."""
+        from app.services.results_shared import build_predictions
+
+        match = MatchResult(
+            matcher_job_id=1,
+            ocr_result_id=10,
+            voter_id=None,
+            rank=1,
+            similarity_score=0.5,
+            confidence_level=ConfidenceLevel.LOW,
+        )
+        session.add(match)
+        session.commit()
+
+        result = build_predictions(session, [match])
+
+        assert result[10][0].voter_name == ""
+        assert result[10][0].voter_address == ""
+
+    def test_predictions_sorted_by_rank(self, session: Session):
+        """Scenario: Multiple predictions per OCR sorted by rank ascending."""
+        from app.services.results_shared import build_predictions
+
+        region = _seed_region(session)
+        voter = RegisteredVoter(
+            region_id=region.id,
+            name_data={"first_name": "A", "last_name": "B"},
+            address_data={},
+            data_hash="h1",
+        )
+        session.add(voter)
+        session.flush()
+
+        for rank in [3, 1, 2]:
+            session.add(
+                MatchResult(
+                    matcher_job_id=1,
+                    ocr_result_id=10,
+                    voter_id=voter.id,
+                    rank=rank,
+                    similarity_score=0.9,
+                    confidence_level=ConfidenceLevel.HIGH,
+                )
+            )
+        session.commit()
+
+        matches = session.exec(
+            __import__("sqlmodel", fromlist=["select"]).select(MatchResult)
+        ).all()
+        result = build_predictions(session, matches)
+
+        assert [p.rank for p in result[10]] == [1, 2, 3]
+
+
+class TestEnrichWithCropScan:
+    """Feature: Crop/scan enrichment.
+
+    As both query services
+    I want shared crop/scan lookup and enrichment
+    So that OCR results get the same thumbnail/coordinate/scan data.
+    """
+
+    def test_enriches_ocr_results_with_crop_and_scan(self, session: Session):
+        """Scenario: OCR results linked to crops and scans get enrichment data."""
+        from app.services.results_shared import enrich_ocr_lookup
+
+        region = _seed_region(session)
+        campaign = _seed_campaign(session, region)
+        scan = _seed_scan(session, campaign)
+        crop = _seed_crop(session, scan)
+        ocr = OcrResult(
+            crop_id=crop.id,
+            ocr_job_id=1,
+            extracted_text={"name": "Test"},
+        )
+        session.add(ocr)
+        session.flush()
+
+        result = enrich_ocr_lookup(session, [ocr.id])
+
+        assert ocr.id in result
+        info = result[ocr.id]
+        assert info.crop_id == crop.id
+        assert info.thumbnail_url == f"/api/crops/{crop.id}/image"
+        assert info.page_number == 1
+        assert info.document_name == "test.pdf"
+
+    def test_enriches_with_orphan_crop_id(self, session: Session):
+        """Scenario: OCR result with crop_id=0 (no matching crop) gets defaults."""
+        from app.services.results_shared import enrich_ocr_lookup
+
+        _seed_region(session)
+        ocr = OcrResult(
+            crop_id=0,
+            ocr_job_id=1,
+            extracted_text={"name": "Orphan"},
+        )
+        session.add(ocr)
+        session.flush()
+
+        result = enrich_ocr_lookup(session, [ocr.id])
+
+        info = result[ocr.id]
+        assert info.crop_id == 0
+        assert info.thumbnail_url == ""
+        assert info.document_name == ""
+
+
+class TestComputeNextCursor:
+    """Feature: Next cursor computation.
+
+    As both query services
+    I want a shared function to determine if next_cursor should be set
+    So that pagination termination is consistent across endpoints.
+    """
+
+    def test_returns_none_when_fewer_than_page_size(self):
+        """Scenario: 3 results with page_size=5 yields no next cursor."""
+        from app.services.results_shared import compute_next_cursor
+
+        result = compute_next_cursor(
+            paginated_ids=[1, 2, 3], page_size=5, count_after=0
+        )
+        assert result is None
+
+    def test_returns_last_id_when_more_results_exist(self):
+        """Scenario: 5 results with page_size=5 and more remaining yields cursor."""
+        from app.services.results_shared import compute_next_cursor
+
+        result = compute_next_cursor(
+            paginated_ids=[10, 20, 30, 40, 50], page_size=5, count_after=3
+        )
+        assert result == 50
+
+    def test_returns_none_when_no_more_results(self):
+        """Scenario: 5 results with page_size=5 but nothing after yields None."""
+        from app.services.results_shared import compute_next_cursor
+
+        result = compute_next_cursor(
+            paginated_ids=[10, 20, 30, 40, 50], page_size=5, count_after=0
+        )
+        assert result is None

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -136,7 +136,7 @@ wheels = [
 
 [[package]]
 name = "ballot-petition-signature-verifier"
-version = "1.0.0a5"
+version = "1.0.0a6"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "frontend",
-	"version": "1.0.0-alpha.5",
+	"version": "1.0.0-alpha.6",
 	"private": true,
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
## Summary

- **Extract shared pagination/prediction logic** into `results_shared.py` — eliminates ~170 lines of duplication between `ResultsQueryService` and `CampaignQueryService`. Both results endpoints now delegate to four shared functions: `validate_pagination_params`, `build_predictions`, `enrich_ocr_lookup`, and `compute_next_cursor`
- **Type campaign router confidence parameter** as `ConfidenceLevel` enum instead of raw string
- **Cache distinct OCR count in job metadata** at scan completion time, avoiding redundant count queries during pagination
- **Eliminate N+1 query** in campaign results endpoint — `OcrEnrichment` data class now includes `raw_extracted_text`, removing per-row `session.get(OcrResult)` calls
- **13 new BDD tests** for the shared module (1327 total tests passing)
- **Version bump** to `1.0.0-alpha.6`

## Test plan

- [x] Full backend test suite passes (1327 tests)
- [x] Ruff lint and format clean
- [x] basedpyright type errors reduced from 28 → 19 in results_query_service