### PR TITLE
fix(docker): upgrade OS packages in frontend prod image

### DIFF
--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -22,6 +22,8 @@ RUN bun run build
 FROM node:20-slim AS runner
 WORKDIR /app
 
+RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
+
 ENV NODE_ENV=production
 ENV HOST=0.0.0.0
 ENV PORT=3000


### PR DESCRIPTION
## Summary

Resolve 8 OpenSSL CVEs (2 CRITICAL, 6 HIGH) in `node:20-slim` Debian 13.4 base image by adding `apt-get upgrade` before app layers.

| CVE | Severity | Fixed |
|-----|----------|-------|
| CVE-2026-31789 | CRITICAL | 3.5.5-1~deb13u2 |
| CVE-2026-28387 | HIGH | 3.5.5-1~deb13u2 |
| CVE-2026-28388 | HIGH | 3.5.5-1~deb13u2 |
| CVE-2026-28389 | HIGH | 3.5.5-1~deb13u2 |

Affects `libssl3t64` and `openssl-provider-legacy`. Backend image scans clean.

## Test plan

- [x] `docker-build` Trivy scan should pass (0 CRITICAL/HIGH)
- [x] Frontend build and runtime unchanged (only OS package upgrade)