### PR TITLE
fix(ci): repair code quality workflow paths

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -15,7 +15,7 @@ jobs:
         uses: astral-sh/setup-uv@v4
         with:
           enable-cache: true
-          cache-dependency-glob: "main/backend/uv.lock"
+          cache-dependency-glob: "backend/uv.lock"
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
@@ -29,18 +29,15 @@ jobs:
         uses: extractions/setup-just@v2
 
       - name: Install backend dependencies
-        working-directory: main
         run: cd backend && uv sync --dev
 
       - name: Install frontend dependencies
-        working-directory: main
         run: cd frontend && bun install --frozen-lockfile
 
       - name: Install code quality tools
         run: npm install -g jscpd fallow
 
       - name: Run fallow analysis (frontend — SvelteKit)
-        working-directory: main
         run: cd frontend && npx fallow --format json --sarif-file fallow-results.sarif > fallow-results.json
         continue-on-error: true
 
@@ -48,29 +45,24 @@ jobs:
         uses: github/codeql-action/upload-sarif@v3
         if: always()
         with:
-          sarif_file: main/frontend/fallow-results.sarif
+          sarif_file: frontend/fallow-results.sarif
           category: fallow-frontend
 
       - name: Run duplication analysis (backend only)
-        working-directory: main
         run: just duplication
 
       - name: Run complexity analysis
-        working-directory: main
         run: just complexity
 
       - name: Run dead code analysis (backend — Python)
-        working-directory: main
         run: cd backend && uv run vulture app/ vulture_whitelist.py --min-confidence 80 2>&1 | tee ../vulture-report.txt
         continue-on-error: true
 
       - name: Run dead code analysis (frontend — SvelteKit)
-        working-directory: main
         run: cd frontend && npx fallow dead-code --format json > ../fallow-frontend-dead-code.json
         continue-on-error: true
 
       - name: Check quality thresholds
-        working-directory: main
         run: |
           echo "=== Quality Threshold Check ==="
           FAIL=0
@@ -125,11 +117,11 @@ jobs:
         with:
           name: code-quality-reports
           path: |
-            main/jscpd-report/
-            main/vulture-report.txt
-            main/frontend/fallow-results.json
-            main/frontend/fallow-results.sarif
-            main/fallow-frontend-dead-code.json
+            jscpd-report/
+            vulture-report.txt
+            frontend/fallow-results.json
+            frontend/fallow-results.sarif
+            fallow-frontend-dead-code.json
 
       - name: Create failure issue
         if: failure()

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -67,13 +67,15 @@ jobs:
           echo "=== Quality Threshold Check ==="
           FAIL=0
           if [ -f jscpd-report/jscpd-report.html ]; then
-            DUP_PCT=$(grep -oP '\d+(?=%)' jscpd-report/jscpd-report.html | head -1)
+            # Scope to the "Duplicated Lines" stat card; a bare grep for digits
+            # before % matches CSS values like width:100% earlier in the HTML.
+            DUP_PCT=$(grep -A1 'Duplicated Lines' jscpd-report/jscpd-report.html | grep -oP '\d+(?:\.\d+)?(?=%)' | head -1)
             if [ -z "$DUP_PCT" ]; then
               echo "::warning::Could not parse duplication percentage from jscpd report"
               DUP_PCT=0
             fi
             echo "Duplication: ${DUP_PCT}%"
-            if [ "$DUP_PCT" -gt 20 ] 2>/dev/null; then
+            if awk "BEGIN {exit !($DUP_PCT > 20)}"; then
               echo "::error::Duplication above 20% threshold: ${DUP_PCT}%"
               FAIL=1
             fi

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -66,8 +66,8 @@ jobs:
         run: |
           echo "=== Quality Threshold Check ==="
           FAIL=0
-          if [ -f jscpd-report/index.html ]; then
-            DUP_PCT=$(grep -oP '\d+(?=%)' jscpd-report/index.html | head -1)
+          if [ -f jscpd-report/jscpd-report.html ]; then
+            DUP_PCT=$(grep -oP '\d+(?=%)' jscpd-report/jscpd-report.html | head -1)
             if [ -z "$DUP_PCT" ]; then
               echo "::warning::Could not parse duplication percentage from jscpd report"
               DUP_PCT=0


### PR DESCRIPTION
## What & why

Fixes the nightly **Code Quality Analysis** workflow, which was hard-failing at setup time. Three bugs, three commits. Tracking issue: #54.

## Changes

### 1. Invalid `main/` path prefixes (89da206)

`main/` path prefixes and `working-directory: main` directives were introduced in 610848b. GitHub Actions checks out the repo at the workspace root — there is no `main/` directory, so `backend/` and `frontend/` live at the checkout root.

- `cache-dependency-glob: "main/backend/uv.lock"` → `"backend/uv.lock"`
- Removed 8× `working-directory: main`
- `sarif_file: main/frontend/fallow-results.sarif` → `frontend/fallow-results.sarif`
- Removed `main/` prefixes from 5 artifact paths

### 2. Wrong jscpd report filename (e50d92f)

The quality-thresholds step looked for `jscpd-report/index.html`, but jscpd writes `jscpd-report/jscpd-report.html` (per the justfile `duplication` recipe). Without the file the step emitted `::error::jscpd report not found` and failed.

### 3. jscpd duplication-percentage parse bug (5c077d2)

The thresholds step grepped `\d+(?=%)` and took the first match, which was `100` from the report's CSS (`width: 100%`) — a false positive that tripped the 20% gate every run. The real duplication rate is 2.20%.

- Scope the grep to the "Duplicated Lines" stat card so only the real rate is matched.
- Switch the threshold check from bash integer `-gt` to `awk` so decimal percentages (e.g. `2.20%`) compare correctly. The previous `[ "$DUP_PCT" -gt 20 ]` silently errored on non-integer values (suppressed by `2>/dev/null`), which would have been a false negative above 20%.

## Scope

Path + parse fixes only — minimal blast radius. Action-version upgrades (`checkout@v5`, `setup-bun@v2`, `upload-sarif@v4`, etc.) are intentionally excluded (deferred to a later Phase 5 PR).

## Verification

- `git grep "main/\|working-directory: main" -- .github/workflows/code-quality.yml` → no matches.
- Code Quality Analysis workflow run [28145695207](https://github.com/civictechdc/votecatcher/actions/runs/28145695207) via `workflow_dispatch` on this branch → **success**.
- Thresholds step output: `Duplication: 2.20%`, `All quality thresholds passed`.
- Pre-commit hooks: detect-secrets, yaml-check, all passed.

Part of the CI triage effort (2026-06-24), Phase 1.
