### PR TITLE
fix(ci): disable uv cache for full dast

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -554,8 +554,7 @@ jobs:
       - name: Install UV
         uses: astral-sh/setup-uv@v4
         with:
-          enable-cache: true
-          cache-dependency-glob: "backend/uv.lock"
+          enable-cache: false
 
       - name: Cache nuclei binary
         id: cache-nuclei

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -142,14 +142,14 @@
         "filename": ".github/workflows/ci.yml",
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_verified": false,
-        "line_number": 715
+        "line_number": 714
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/ci.yml",
         "hashed_secret": "a128f45f1c9645b721090d0673e656ec295eaded",
         "is_verified": false,
-        "line_number": 715
+        "line_number": 714
       }
     ],
     "Makefile": [
@@ -311,5 +311,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-12T03:05:18Z"
+  "generated_at": "2026-06-25T02:28:56Z"
 }


### PR DESCRIPTION
## What & why

The `dast-full` job's DAST scan passes, but `astral-sh/setup-uv@v4` fails in its **post-step cache pruning** ("Pruning cache..." -> exit code 2), leaving scheduled CI red. This disables the setup-uv cache for `dast-full`, matching `dast-smoke` which already runs with `enable-cache: false`. `dast-full` is a one-shot scheduled scan where cache savings aren't worth a red workflow.

## Changes (`.github/workflows/ci.yml`, `dast-full` job only)

```diff
       - name: Install UV
         uses: astral-sh/setup-uv@v4
         with:
-          enable-cache: true
-          cache-dependency-glob: "backend/uv.lock"
+          enable-cache: false
```

Also includes the required `.secrets.baseline` line-number update (detect-secrets) for the removed line.

## Verification
`dast-full` is schedule-only (`if: github.event_name == 'schedule'`), so it won't run on this PR. Verify via the next scheduled CI run, or temporarily add `workflow_dispatch` to test on the branch.

Part of the CI triage effort (2026-06-24), Phase 4.
