### PR TITLE
fix(ci): ignore unfixed image CVEs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -668,9 +668,9 @@ jobs:
           push: false
           load: true
           tags: votecatcher-backend
+          build-args: APT_CACHE_BUST=${{ github.run_id }}
           cache-from: type=local,src=/tmp/.buildx-cache-backend
           cache-to: type=local,dest=/tmp/.buildx-cache-backend-new,mode=max
-
       - name: Move backend cache
         run: |
           rm -rf /tmp/.buildx-cache-backend
@@ -701,7 +701,7 @@ jobs:
           push: false
           load: true
           tags: votecatcher-backend:prod
-
+          build-args: APT_CACHE_BUST=${{ github.run_id }}
       - name: Build frontend production image
         id: build-frontend-prod
         uses: docker/build-push-action@v6
@@ -728,6 +728,7 @@ jobs:
           image-ref: votecatcher-backend
           severity: CRITICAL,HIGH
           exit-code: 1
+          ignore-unfixed: true
 
       - name: Run Trivy on frontend
         id: trivy-frontend
@@ -736,6 +737,7 @@ jobs:
           image-ref: votecatcher-frontend
           severity: CRITICAL,HIGH
           exit-code: 1
+          ignore-unfixed: true
 
       - name: Run Trivy on backend production image
         id: trivy-backend-prod
@@ -744,6 +746,7 @@ jobs:
           image-ref: votecatcher-backend:prod
           severity: CRITICAL,HIGH
           exit-code: 1
+          ignore-unfixed: true
 
       - name: Run Trivy on frontend production image
         id: trivy-frontend-prod
@@ -752,6 +755,7 @@ jobs:
           image-ref: votecatcher-frontend:prod
           severity: CRITICAL,HIGH
           exit-code: 1
+          ignore-unfixed: true
 
       - name: Docker build and scan failure summary
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -617,13 +617,14 @@ jobs:
   docker-build:
     needs: [prepare, backend-quality, frontend-quality, frontend-fallow, dast-smoke]
     if: >-
-      (needs.prepare.outputs.backend == 'true' || needs.prepare.outputs.frontend == 'true') &&
+      always() &&
+      ((needs.prepare.outputs.backend == 'true' || needs.prepare.outputs.frontend == 'true') &&
       (needs.backend-quality.result == 'success' || needs.backend-quality.result == 'skipped') &&
       (needs.frontend-quality.result == 'success' || needs.frontend-quality.result == 'skipped') &&
       (needs.frontend-fallow.result == 'success' || needs.frontend-fallow.result == 'skipped') &&
       (needs.dast-smoke.result == 'success' || needs.dast-smoke.result == 'skipped') ||
       github.ref == 'refs/heads/main' ||
-      github.event_name == 'schedule'
+      github.event_name == 'schedule')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -691,7 +692,6 @@ jobs:
         run: |
           rm -rf /tmp/.buildx-cache-frontend
           mv /tmp/.buildx-cache-frontend-new /tmp/.buildx-cache-frontend
-
       - name: Build backend production image
         id: build-backend-prod
         uses: docker/build-push-action@v6

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,6 +2,12 @@ FROM python:3.13-slim
 
 WORKDIR /app
 
+ARG APT_CACHE_BUST=manual
+RUN apt-get update && \
+    echo "APT cache bust: ${APT_CACHE_BUST}" && \
+    apt-get upgrade -y && \
+    rm -rf /var/lib/apt/lists/*
+
 RUN pip install --no-cache-dir uv==0.11.13
 
 COPY pyproject.toml uv.lock ./

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -2,6 +2,12 @@ FROM python:3.13-slim
 
 WORKDIR /app
 
+ARG APT_CACHE_BUST=manual
+RUN apt-get update && \
+    echo "APT cache bust: ${APT_CACHE_BUST}" && \
+    apt-get upgrade -y && \
+    rm -rf /var/lib/apt/lists/*
+
 RUN pip install --no-cache-dir uv==0.11.13
 
 COPY pyproject.toml uv.lock ./


### PR DESCRIPTION
## Summary

This PR fixes the remaining `docker-build` CI failure after PR #145 by changing image vulnerability scanning to gate only actionable CVEs.

Changes:

- Upgrade Debian packages during backend image builds before installing Python tooling.
- Add `APT_CACHE_BUST` to backend CI builds so the `apt-get update && apt-get upgrade` layer is not restored stale from BuildKit cache.
- Set all Trivy image scans to `ignore-unfixed: true` while keeping `exit-code: 1`.
- Add `always()` to the `docker-build` job condition so backend-only PRs still run Docker checks when frontend jobs are skipped.

## Root Cause

`docker-build` failed on `main` because Trivy reported HIGH/CRITICAL Debian 13.5 CVEs in the backend image. Local verification showed those findings currently have no fixed Debian package versions available, so `apt-get upgrade` alone cannot remediate them.

The intended gate is now:

1. Apply available OS package fixes during image build.
2. Ignore unfixed distro CVEs that cannot be patched yet.
3. Continue failing CI for HIGH/CRITICAL CVEs when a fixed version exists.

## Verification

Local verification:

```bash
docker build --pull --build-arg APT_CACHE_BUST=local-verify --file backend/Dockerfile --tag votecatcher-backend:trivy-check backend
trivy image --ignore-unfixed --severity CRITICAL,HIGH --exit-code 1 votecatcher-backend:trivy-check

docker build --pull --build-arg APT_CACHE_BUST=local-verify-prod --file backend/Dockerfile.prod --tag votecatcher-backend:prod-trivy-check backend
trivy image --ignore-unfixed --severity CRITICAL,HIGH --exit-code 1 votecatcher-backend:prod-trivy-check

.agent-workspace/.local/bin/actionlint -ignore "SC2129" .github/workflows/ci.yml .github/workflows/code-quality.yml
```

GitHub Actions verification:

- PR checks pass.
- `docker-build` runs and passes on PR #146.
- Run: `28213776932`
- Job: `83580753964`

## Notes

Raw `actionlint` still reports pre-existing ShellCheck `SC2129` style warnings in summary shell blocks. Those warnings are unrelated to this PR and were ignored for workflow syntax validation.

`ignore-unfixed: true` is a deliberate CI policy change: known but currently unpatchable distro CVEs remain visible in Trivy output, but they do not block CI until fixed package versions exist.