### PR TITLE
ci: fix changelog benchmark install

### DIFF
--- a/.github/workflows/changelog-benchmark.yml
+++ b/.github/workflows/changelog-benchmark.yml
@@ -25,7 +25,13 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install git-cliff
-        run: curl -sfL https://github.com/orhun/git-cliff/releases/latest/download/git-cliff-linux-x86_64-unknown-linux-gnu.tar.gz | tar xz --strip-components=1 -C /usr/local/bin
+        env:
+          GIT_CLIFF_VERSION: "2.13.1"
+        run: |
+          set -euo pipefail
+          curl -sfL "https://github.com/orhun/git-cliff/releases/download/v${GIT_CLIFF_VERSION}/git-cliff-${GIT_CLIFF_VERSION}-x86_64-unknown-linux-gnu.tar.gz" \
+            | tar xz --strip-components=1 -C /usr/local/bin
+          git-cliff --version
 
       - name: Install Python deps
         run: pip install --quiet jq 2>/dev/null; which jq || apt-get install -y jq


### PR DESCRIPTION
## Summary
- Pin git-cliff installation in the Changelog Benchmarks workflow to version 2.13.1.
- Replace the broken latest-release asset URL with the valid versioned release asset.
- Add an install-time git-cliff --version check so failures surface immediately.

## Verification
- Release asset URL resolves to HTTP 200.
- git diff --check passes.
- Workflow YAML parses successfully.
- Pre-commit hooks passed during commit.