### PR TITLE
fix(worker): runtime orphan recovery for stuck OCR jobs

### DIFF
--- a/backend/app/jobs/worker.py
+++ b/backend/app/jobs/worker.py
@@ -11,7 +11,7 @@ import asyncio
 import base64
 import random
 import time
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -46,6 +46,8 @@ OCR_RETRY_DELAY_SECONDS = 5.0
 OCR_MAX_RETRIES = 3
 MATCHING_DELAY_SECONDS = 0.5
 BATCH_THRESHOLD = 5
+ORPHAN_CHECK_INTERVAL_SECONDS = 60
+ORPHAN_TIMEOUT_SECONDS = 300
 
 
 class JobWorker:
@@ -63,6 +65,7 @@ class JobWorker:
     def __init__(self, settings: "Settings | None" = None) -> None:
         self.settings = settings or get_settings()
         self.running = False
+        self._last_orphan_check: float = 0.0
 
     async def start(self) -> None:
         """Start the worker loop."""
@@ -77,6 +80,16 @@ class JobWorker:
                 await self._process_pending_jobs()
             except Exception as e:
                 logger.error("Worker error", error=str(e))
+
+            if (
+                time.monotonic() - self._last_orphan_check
+                >= ORPHAN_CHECK_INTERVAL_SECONDS
+            ):
+                try:
+                    await self._recover_orphaned_jobs()
+                except Exception as e:
+                    logger.error("Orphan recovery error", error=str(e))
+                self._last_orphan_check = time.monotonic()
 
             await asyncio.sleep(POLL_INTERVAL_SECONDS)
 
@@ -167,6 +180,84 @@ class JobWorker:
         """
         with Session(engine) as session:
             return self._terminate_orphans_with_session(session)
+
+    async def _recover_orphaned_jobs(self) -> int:
+        """Run periodic orphan recovery, resetting stale jobs to NOT_STARTED."""
+        with Session(engine) as session:
+            return self._recover_orphaned_jobs_with_session(session)
+
+    def _recover_orphaned_jobs_with_session(self, session: Session) -> int:
+        """Reset stale orphaned jobs to NOT_STARTED for automatic retry.
+
+        Unlike startup termination which moves to error states, this method
+        resets to NOT_STARTED so the existing _process_pending_jobs loop
+        picks them up for retry.
+
+        Args:
+                session: Database session
+
+        Returns:
+                Number of jobs recovered
+        """
+        orphan_states = [
+            JobStatus.OCR_STARTED,
+            JobStatus.OCR_COMPLETED,
+            JobStatus.MATCHING_PENDING,
+            JobStatus.MATCHING,
+        ]
+        threshold = datetime.now(UTC) - timedelta(seconds=ORPHAN_TIMEOUT_SECONDS)
+
+        stale_jobs = session.exec(
+            select(MatcherJob).where(
+                MatcherJob.current_status.in_(orphan_states),
+                (MatcherJob.started_on < threshold) | (MatcherJob.started_on.is_(None)),
+            )
+        ).all()
+
+        if not stale_jobs:
+            return 0
+
+        terminal_ocr = [
+            JobStatus.OCR_COMPLETED,
+            JobStatus.OCR_FAILED,
+            JobStatus.CANCELLED,
+            JobStatus.MATCHING_COMPLETED,
+            JobStatus.MATCHING_ERROR,
+        ]
+
+        recovered = 0
+        for job in stale_jobs:
+            previous_status = job.current_status.value
+            job.current_status = JobStatus.NOT_STARTED
+            job.started_on = None
+            job.ended_on = None
+            job.error_data = {
+                "recovered": True,
+                "previous_status": previous_status,
+                "timestamp": datetime.now(UTC).isoformat(),
+            }
+
+            child_ocr_jobs = session.exec(
+                select(OcrJob).where(
+                    OcrJob.matcher_job_id == job.id,
+                    OcrJob.status.not_in(terminal_ocr),
+                )
+            ).all()
+            for ocr_job in child_ocr_jobs:
+                ocr_job.status = JobStatus.NOT_STARTED
+
+            logger.info(
+                "Orphaned job recovered",
+                job_id=job.id,
+                previous_status=previous_status,
+                campaign_id=str(job.campaign_id),
+            )
+            recovered += 1
+
+        session.commit()
+        logger.info("Periodic orphan recovery complete", count=recovered)
+
+        return recovered
 
     async def _process_pending_jobs(self) -> None:
         """Process all pending jobs in NOT_STARTED state."""

--- a/backend/app/routers/job_router.py
+++ b/backend/app/routers/job_router.py
@@ -133,6 +133,21 @@ def start_job(
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=error_msg)
 
 
+@router.post("/{job_id}/retry", response_model=JobResponse)
+def retry_job(
+    job_id: int,
+    session: SessionDep,
+) -> JobResponse:
+    """Retry a failed or stuck job."""
+    try:
+        return JobQueryService(session).retry_job(job_id)
+    except ValueError as e:
+        error_msg = str(e)
+        if "not found" in error_msg:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=error_msg)
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=error_msg)
+
+
 @router.get("/{job_id}/status", response_class=StreamingResponse)
 async def get_job_status_stream(
     job_id: int,

--- a/backend/app/services/job_query_service.py
+++ b/backend/app/services/job_query_service.py
@@ -10,7 +10,7 @@ from sqlmodel import Session, select
 if TYPE_CHECKING:
     from app.routers.job_router import JobListResponse, JobResponse
 
-from app.data.database.model.jobs import JobStatus, MatcherJob
+from app.data.database.model.jobs import JobStatus, MatcherJob, OcrJob
 from app.data.database.model.petition_scan import PetitionScan
 from app.data.database.model.schema import Campaign
 from app.data.database.model.voter_list_upload import UploadStatus, VoterListUpload
@@ -44,6 +44,16 @@ _RETRYABLE_STATES = frozenset(
         JobStatus.OCR_COMPLETED,
         JobStatus.MATCHING_PENDING,
         JobStatus.MATCHING,
+    }
+)
+
+_TERMINAL_OCR_STATES = frozenset(
+    {
+        JobStatus.OCR_COMPLETED,
+        JobStatus.OCR_FAILED,
+        JobStatus.CANCELLED,
+        JobStatus.MATCHING_COMPLETED,
+        JobStatus.MATCHING_ERROR,
     }
 )
 
@@ -234,6 +244,14 @@ class JobQueryService:
         job.started_on = None
         job.ended_on = None
         job.error_data = {}
+
+        child_ocr_jobs = self._session.exec(
+            select(OcrJob).where(OcrJob.matcher_job_id == job.id)
+        ).all()
+        for ocr_job in child_ocr_jobs:
+            if ocr_job.status not in _TERMINAL_OCR_STATES:
+                ocr_job.status = JobStatus.NOT_STARTED
+
         self._session.add(job)
         self._session.commit()
         self._session.refresh(job)

--- a/backend/app/services/job_query_service.py
+++ b/backend/app/services/job_query_service.py
@@ -35,6 +35,18 @@ _CANCELABLE_STATES = frozenset(
     ]
 )
 
+_RETRYABLE_STATES = frozenset(
+    {
+        JobStatus.OCR_FAILED,
+        JobStatus.OCR_TIMEOUT,
+        JobStatus.MATCHING_ERROR,
+        JobStatus.OCR_STARTED,
+        JobStatus.OCR_COMPLETED,
+        JobStatus.MATCHING_PENDING,
+        JobStatus.MATCHING,
+    }
+)
+
 
 class JobQueryService:
     """Service for querying and mutating matcher jobs."""
@@ -191,6 +203,37 @@ class JobQueryService:
             raise ValueError("Cannot start job: Campaign has no petition scans")
 
         job.current_status = JobStatus.OCR_PENDING
+        self._session.add(job)
+        self._session.commit()
+        self._session.refresh(job)
+
+        return self._build_job_response(job)
+
+    def retry_job(self, job_id: int) -> JobResponse:
+        """Retry a failed or stuck job by resetting it to NOT_STARTED.
+
+        Args:
+            job_id: Job ID to retry
+
+        Returns:
+            JobResponse with updated status
+
+        Raises:
+            ValueError: If job not found or cannot be retried in current state
+        """
+        job = self._session.get(MatcherJob, job_id)
+        if not job:
+            raise ValueError(f"Job {job_id} not found")
+
+        if job.current_status not in _RETRYABLE_STATES:
+            raise ValueError(
+                f"Job cannot be retried in state {job.current_status.value}"
+            )
+
+        job.current_status = JobStatus.NOT_STARTED
+        job.started_on = None
+        job.ended_on = None
+        job.error_data = {}
         self._session.add(job)
         self._session.commit()
         self._session.refresh(job)

--- a/backend/tests/integration/api/test_jobs.py
+++ b/backend/tests/integration/api/test_jobs.py
@@ -11,9 +11,9 @@ Tests the complete job lifecycle:
 import uuid
 
 from fastapi.testclient import TestClient
-from sqlmodel import Session
+from sqlmodel import Session, select
 
-from app.data.database.model.jobs import JobStatus, MatcherJob
+from app.data.database.model.jobs import JobStatus, MatcherJob, OcrJob
 from app.data.database.model.llm_provider_config import LlmProviderConfig
 from app.data.database.model.petition_scan import PetitionScan
 from app.data.database.model.schema import Campaign
@@ -29,13 +29,17 @@ def _seed_prerequisites(session: Session, campaign: Campaign) -> None:
         status=UploadStatus.ACTIVE,
     )
     session.add(upload)
-    provider = LlmProviderConfig(
-        provider="openai",
-        api_key="sk-test-key-for-integration-tests",  # pragma: allowlist secret
-        model="gpt-4o-mini",
-        is_configured=True,
-    )
-    session.add(provider)
+    provider = session.exec(
+        select(LlmProviderConfig).where(LlmProviderConfig.provider == "openai")
+    ).first()
+    if provider is None:
+        provider = LlmProviderConfig(
+            provider="openai",
+            api_key="sk-test-key-for-integration-tests",  # pragma: allowlist secret
+            model="gpt-4o-mini",
+            is_configured=True,
+        )
+        session.add(provider)
     session.flush()
 
 
@@ -386,6 +390,101 @@ class TestStartJob:
         response = client.post(f"/api/jobs/{job.id}/start")
 
         assert response.status_code == 400
+
+
+class TestRetryJob:
+    """Tests for POST /api/jobs/{job_id}/retry endpoint."""
+
+    def test_retry_stuck_job_resets_job_and_child_ocr(
+        self, client: TestClient, test_campaign: Campaign, session: Session
+    ):
+        """Should reset stuck matcher job and non-terminal child OCR job."""
+        job = MatcherJob(
+            campaign_id=test_campaign.id,
+            current_status=JobStatus.OCR_STARTED,
+        )
+        session.add(job)
+        session.commit()
+        session.refresh(job)
+        ocr_job = OcrJob(
+            matcher_job_id=job.id,
+            status=JobStatus.OCR_STARTED,
+        )
+        session.add(ocr_job)
+        session.commit()
+        session.refresh(ocr_job)
+
+        response = client.post(f"/api/jobs/{job.id}/retry")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == JobStatus.NOT_STARTED.value
+        session.refresh(job)
+        session.refresh(ocr_job)
+        assert job.current_status == JobStatus.NOT_STARTED
+        assert ocr_job.status == JobStatus.NOT_STARTED
+
+    def test_retry_completed_job_rejected(
+        self, client: TestClient, test_campaign: Campaign, session: Session
+    ):
+        """Should reject retry for terminal successful jobs."""
+        job = MatcherJob(
+            campaign_id=test_campaign.id,
+            current_status=JobStatus.MATCHING_COMPLETED,
+        )
+        session.add(job)
+        session.commit()
+        session.refresh(job)
+
+        response = client.post(f"/api/jobs/{job.id}/retry")
+
+        assert response.status_code == 400
+        assert "cannot be retried" in response.json()["detail"]
+
+    def test_retry_missing_job_returns_404(self, client: TestClient):
+        """Should return 404 when retrying a missing job."""
+        response = client.post("/api/jobs/999999/retry")
+
+        assert response.status_code == 404
+
+    def test_retry_matching_job_resets_to_not_started(
+        self, client: TestClient, test_campaign: Campaign, session: Session
+    ):
+        """Should reset a job stuck in MATCHING to NOT_STARTED."""
+        job = MatcherJob(
+            campaign_id=test_campaign.id,
+            current_status=JobStatus.MATCHING,
+        )
+        session.add(job)
+        session.commit()
+        session.refresh(job)
+
+        response = client.post(f"/api/jobs/{job.id}/retry")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == JobStatus.NOT_STARTED.value
+        session.refresh(job)
+        assert job.current_status == JobStatus.NOT_STARTED
+
+    def test_retry_failed_job_clears_error_data(
+        self, client: TestClient, test_campaign: Campaign, session: Session
+    ):
+        """Should clear error_data when retrying a failed job."""
+        job = MatcherJob(
+            campaign_id=test_campaign.id,
+            current_status=JobStatus.OCR_FAILED,
+            error_data={"message": "OCR provider error"},
+        )
+        session.add(job)
+        session.commit()
+        session.refresh(job)
+
+        response = client.post(f"/api/jobs/{job.id}/retry")
+
+        assert response.status_code == 200
+        session.refresh(job)
+        assert job.error_data == {}
 
 
 class TestJobOrphanStatus:

--- a/backend/tests/unit/jobs/test_orphan_termination.py
+++ b/backend/tests/unit/jobs/test_orphan_termination.py
@@ -8,10 +8,16 @@ Scenarios covered:
   - Orphaned job error_data contains termination metadata
   - Orphaned OcrJob children are also terminated
   - JobStatusEvent is published for each terminated orphan
+  - Periodic runtime recovery: stale jobs reset to NOT_STARTED
+  - Periodic recovery leaves fresh jobs untouched
+  - Periodic recovery clears timing fields
+  - Periodic recovery resets child OcrJob records
 """
 
+from datetime import UTC, datetime, timedelta
+
 import pytest
-from sqlmodel import Session, SQLModel, create_engine
+from sqlmodel import Session, SQLModel, create_engine, select
 
 from app.data.database.model.jobs import JobStatus, MatcherJob, OcrJob
 from app.data.database.model.schema import Campaign, Region
@@ -198,3 +204,165 @@ class TestMultipleOrphansAllTerminated:
         assert job1.current_status == JobStatus.OCR_FAILED
         assert job2.current_status == JobStatus.MATCHING_ERROR
         assert job3.current_status == JobStatus.MATCHING_ERROR
+
+
+def _create_stale_job(session, campaign, status, minutes_stale=6):
+    job = MatcherJob(
+        campaign_id=campaign.id,
+        current_status=status,
+        started_on=datetime.now(UTC) - timedelta(minutes=minutes_stale),
+        ended_on=datetime.now(UTC) - timedelta(minutes=minutes_stale - 1)
+        if minutes_stale > 1
+        else None,
+    )
+    session.add(job)
+    session.commit()
+    session.refresh(job)
+    return job
+
+
+class TestPeriodicOrphanRecoveryOcrStarted:
+    """Scenario: Job in OCR_STARTED for >5min gets reset to NOT_STARTED."""
+
+    def test_status_reset_to_not_started(self, session, sample_campaign):
+        from app.jobs.worker import JobWorker
+
+        _create_stale_job(
+            session, sample_campaign, JobStatus.OCR_STARTED, minutes_stale=6
+        )
+        worker = JobWorker()
+        worker._recover_orphaned_jobs_with_session(session)
+
+        job = session.exec(select(MatcherJob)).first()
+        assert job.current_status == JobStatus.NOT_STARTED
+
+    def test_started_on_cleared(self, session, sample_campaign):
+        from app.jobs.worker import JobWorker
+
+        _create_stale_job(
+            session, sample_campaign, JobStatus.OCR_STARTED, minutes_stale=6
+        )
+        worker = JobWorker()
+        worker._recover_orphaned_jobs_with_session(session)
+
+        job = session.exec(select(MatcherJob)).first()
+        assert job.started_on is None
+
+    def test_ended_on_cleared(self, session, sample_campaign):
+        from app.jobs.worker import JobWorker
+
+        _create_stale_job(
+            session, sample_campaign, JobStatus.OCR_STARTED, minutes_stale=6
+        )
+        worker = JobWorker()
+        worker._recover_orphaned_jobs_with_session(session)
+
+        job = session.exec(select(MatcherJob)).first()
+        assert job.ended_on is None
+
+    def test_error_data_contains_recovery_metadata(self, session, sample_campaign):
+        from app.jobs.worker import JobWorker
+
+        _create_stale_job(
+            session, sample_campaign, JobStatus.OCR_STARTED, minutes_stale=6
+        )
+        worker = JobWorker()
+        worker._recover_orphaned_jobs_with_session(session)
+
+        job = session.exec(select(MatcherJob)).first()
+        assert job.error_data.get("recovered") is True
+        assert "previous_status" in job.error_data
+
+
+class TestPeriodicOrphanRecoveryNotTooEarly:
+    """Scenario: Job in OCR_STARTED for <5min is left alone."""
+
+    def test_status_unchanged(self, session, sample_campaign):
+        from app.jobs.worker import JobWorker
+
+        _create_stale_job(
+            session, sample_campaign, JobStatus.OCR_STARTED, minutes_stale=2
+        )
+        worker = JobWorker()
+        worker._recover_orphaned_jobs_with_session(session)
+
+        job = session.exec(select(MatcherJob)).first()
+        assert job.current_status == JobStatus.OCR_STARTED
+
+
+class TestPeriodicOrphanRecoveryMatching:
+    """Scenario: Job in MATCHING for >5min gets reset to NOT_STARTED."""
+
+    def test_status_reset_to_not_started(self, session, sample_campaign):
+        from app.jobs.worker import JobWorker
+
+        _create_stale_job(session, sample_campaign, JobStatus.MATCHING, minutes_stale=6)
+        worker = JobWorker()
+        worker._recover_orphaned_jobs_with_session(session)
+
+        job = session.exec(select(MatcherJob)).first()
+        assert job.current_status == JobStatus.NOT_STARTED
+
+
+class TestPeriodicRecoveryNormalJobsUntouched:
+    """Scenario: Jobs in NOT_STARTED and terminal states are never touched."""
+
+    @pytest.mark.parametrize(
+        "status",
+        [
+            JobStatus.NOT_STARTED,
+            JobStatus.MATCHING_COMPLETED,
+            JobStatus.OCR_FAILED,
+            JobStatus.CANCELLED,
+        ],
+    )
+    def test_status_unchanged(self, session, sample_campaign, status):
+        from app.jobs.worker import JobWorker
+
+        _create_job(session, sample_campaign, status)
+        worker = JobWorker()
+        worker._recover_orphaned_jobs_with_session(session)
+
+        job = session.exec(select(MatcherJob)).first()
+        assert job.current_status == status
+
+
+class TestPeriodicRecoveryClearsTimings:
+    """Scenario: started_on and ended_on are cleared on recovery reset."""
+
+    def test_both_timings_cleared(self, session, sample_campaign):
+        from app.jobs.worker import JobWorker
+
+        _create_stale_job(
+            session, sample_campaign, JobStatus.OCR_STARTED, minutes_stale=6
+        )
+        worker = JobWorker()
+        worker._recover_orphaned_jobs_with_session(session)
+
+        job = session.exec(select(MatcherJob)).first()
+        assert job.started_on is None
+        assert job.ended_on is None
+
+
+class TestPeriodicRecoveryResetsChildOcrJobs:
+    """Scenario: Child OcrJob records are also reset to NOT_STARTED."""
+
+    def test_child_ocr_job_reset(self, session, sample_campaign):
+        from app.jobs.worker import JobWorker
+
+        job = _create_stale_job(
+            session, sample_campaign, JobStatus.OCR_STARTED, minutes_stale=6
+        )
+        ocr_job = OcrJob(
+            matcher_job_id=job.id,
+            status=JobStatus.OCR_STARTED,
+        )
+        session.add(ocr_job)
+        session.commit()
+        session.refresh(ocr_job)
+
+        worker = JobWorker()
+        worker._recover_orphaned_jobs_with_session(session)
+
+        session.refresh(ocr_job)
+        assert ocr_job.status == JobStatus.NOT_STARTED

--- a/backend/tests/unit/jobs/test_worker_persistence.py
+++ b/backend/tests/unit/jobs/test_worker_persistence.py
@@ -62,7 +62,7 @@ class TestBatchOcrPersistsProviderJobId:
 
             mock_config = MagicMock()
             mock_config.provider = "openai"
-            mock_config.api_key = "test-key"
+            mock_config.api_key = "test-key"  # pragma: allowlist secret
             mock_config.model = "gpt-4o"
 
             mock_client = AsyncMock()
@@ -134,7 +134,7 @@ class TestBatchOcrPersistsProviderJobId:
 
             mock_config = MagicMock()
             mock_config.provider = "openai"
-            mock_config.api_key = "test-key"
+            mock_config.api_key = "test-key"  # pragma: allowlist secret
             mock_config.model = "gpt-4o"
 
             call_order = []
@@ -258,7 +258,7 @@ class TestBatchOcrPollingTermination:
 
             mock_config = MagicMock()
             mock_config.provider = "openai"
-            mock_config.api_key = "test-key"
+            mock_config.api_key = "test-key"  # pragma: allowlist secret
             mock_config.model = "gpt-4o"
 
             mock_client = AsyncMock()
@@ -317,3 +317,22 @@ class TestBatchOcrPollingTermination:
                 f"fetch_job_status called {mock_client.fetch_job_status.call_count} times "
                 f"for {terminal_status.value}, expected at most 1"
             )
+
+
+class TestOrphanCheckInterval:
+    """Worker must track last orphan check time and only fire after ORPHAN_CHECK_INTERVAL_SECONDS."""
+
+    def test_last_orphan_check_initialized_to_zero(self):
+        from app.jobs.worker import JobWorker
+
+        worker = JobWorker()
+        assert worker._last_orphan_check == 0.0
+
+    @pytest.mark.asyncio
+    async def test_recover_fires_after_interval(self):
+        from app.jobs.worker import JobWorker
+
+        worker = JobWorker()
+        worker._last_orphan_check = 0.0
+        recovered = worker._recover_orphaned_jobs_with_session(MagicMock())
+        assert isinstance(recovered, int)

--- a/backend/tests/unit/services/test_job_query_service_retry.py
+++ b/backend/tests/unit/services/test_job_query_service_retry.py
@@ -1,0 +1,210 @@
+"""Tests for JobQueryService.retry_job method.
+
+Scenarios covered:
+  - Retry from error state (OCR_FAILED) resets to NOT_STARTED
+  - Retry from orphan state (OCR_STARTED) resets to NOT_STARTED
+  - Retry from MATCHING state resets to NOT_STARTED
+  - Retry on not-found raises ValueError
+  - Retry on MATCHING_COMPLETED rejected
+  - Retry on CANCELLED rejected
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlmodel import Session, SQLModel, create_engine
+
+from app.data.database.model.jobs import JobStatus, MatcherJob
+from app.data.database.model.schema import Campaign, Region
+from app.services.job_query_service import JobQueryService
+
+
+@pytest.fixture
+def engine():
+    eng = create_engine("sqlite:///:memory:", echo=False)
+    SQLModel.metadata.create_all(eng)
+    return eng
+
+
+@pytest.fixture
+def session(engine):
+    with Session(engine) as s:
+        yield s
+
+
+@pytest.fixture
+def sample_region(session):
+    region = Region(
+        region_key="DC",
+        region_name="Washington, DC",
+        country_code="US",
+    )
+    session.add(region)
+    session.commit()
+    session.refresh(region)
+    return region
+
+
+@pytest.fixture
+def sample_campaign(session, sample_region):
+    campaign = Campaign(
+        unique_name="retry-test",
+        title="Retry Test",
+        year="2025",
+        region_id=sample_region.id,
+    )
+    session.add(campaign)
+    session.commit()
+    session.refresh(campaign)
+    return campaign
+
+
+def _create_job_with_status(session, campaign, status, **kwargs):
+    job = MatcherJob(
+        campaign_id=campaign.id,
+        current_status=status,
+        **kwargs,
+    )
+    session.add(job)
+    session.commit()
+    session.refresh(job)
+    return job
+
+
+class TestRetryJobResetsErrorStateToNotStarted:
+    def test_ocr_failed_to_not_started(self, session, sample_campaign):
+        job = _create_job_with_status(
+            session,
+            sample_campaign,
+            JobStatus.OCR_FAILED,
+            started_on=datetime.now(UTC) - timedelta(minutes=10),
+            ended_on=datetime.now(UTC) - timedelta(minutes=9),
+            error_data={"message": "OCR provider error"},
+        )
+        service = JobQueryService(session)
+        result = service.retry_job(job.id)
+
+        assert result.status == JobStatus.NOT_STARTED.value
+        session.refresh(job)
+        assert job.started_on is None
+        assert job.ended_on is None
+        assert job.error_data == {}
+
+    def test_ocr_timeout_to_not_started(self, session, sample_campaign):
+        job = _create_job_with_status(
+            session,
+            sample_campaign,
+            JobStatus.OCR_TIMEOUT,
+            started_on=datetime.now(UTC) - timedelta(minutes=10),
+            ended_on=datetime.now(UTC) - timedelta(minutes=9),
+            error_data={"message": "OCR timed out"},
+        )
+        service = JobQueryService(session)
+        result = service.retry_job(job.id)
+
+        assert result.status == JobStatus.NOT_STARTED.value
+        session.refresh(job)
+        assert job.started_on is None
+        assert job.ended_on is None
+        assert job.error_data == {}
+
+    def test_matching_error_to_not_started(self, session, sample_campaign):
+        job = _create_job_with_status(
+            session,
+            sample_campaign,
+            JobStatus.MATCHING_ERROR,
+            error_data={"message": "matching failed"},
+        )
+        service = JobQueryService(session)
+        result = service.retry_job(job.id)
+
+        assert result.status == JobStatus.NOT_STARTED.value
+        session.refresh(job)
+        assert job.error_data == {}
+
+
+class TestRetryJobResetsOrphanState:
+    def test_ocr_started_to_not_started(self, session, sample_campaign):
+        job = _create_job_with_status(
+            session,
+            sample_campaign,
+            JobStatus.OCR_STARTED,
+            started_on=datetime.now(UTC) - timedelta(minutes=6),
+        )
+        service = JobQueryService(session)
+        result = service.retry_job(job.id)
+
+        assert result.status == JobStatus.NOT_STARTED.value
+        session.refresh(job)
+        assert job.started_on is None
+
+    def test_ocr_completed_to_not_started(self, session, sample_campaign):
+        job = _create_job_with_status(
+            session,
+            sample_campaign,
+            JobStatus.OCR_COMPLETED,
+            started_on=datetime.now(UTC) - timedelta(minutes=6),
+        )
+        service = JobQueryService(session)
+        result = service.retry_job(job.id)
+
+        assert result.status == JobStatus.NOT_STARTED.value
+        session.refresh(job)
+        assert job.started_on is None
+
+    def test_matching_pending_to_not_started(self, session, sample_campaign):
+        job = _create_job_with_status(
+            session,
+            sample_campaign,
+            JobStatus.MATCHING_PENDING,
+            started_on=datetime.now(UTC) - timedelta(minutes=6),
+        )
+        service = JobQueryService(session)
+        result = service.retry_job(job.id)
+
+        assert result.status == JobStatus.NOT_STARTED.value
+        session.refresh(job)
+        assert job.started_on is None
+
+    def test_matching_to_not_started(self, session, sample_campaign):
+        job = _create_job_with_status(
+            session,
+            sample_campaign,
+            JobStatus.MATCHING,
+            started_on=datetime.now(UTC) - timedelta(minutes=6),
+        )
+        service = JobQueryService(session)
+        result = service.retry_job(job.id)
+
+        assert result.status == JobStatus.NOT_STARTED.value
+
+
+class TestRetryJobNotFound:
+    def test_raises_value_error(self, session):
+        service = JobQueryService(session)
+        with pytest.raises(ValueError, match="not found"):
+            service.retry_job(99999)
+
+
+class TestRetryJobTerminalCompleteRejected:
+    def test_matching_completed_rejected(self, session, sample_campaign):
+        job = _create_job_with_status(
+            session,
+            sample_campaign,
+            JobStatus.MATCHING_COMPLETED,
+        )
+        service = JobQueryService(session)
+        with pytest.raises(ValueError, match="cannot be retried"):
+            service.retry_job(job.id)
+
+
+class TestRetryJobCancelledRejected:
+    def test_cancelled_rejected(self, session, sample_campaign):
+        job = _create_job_with_status(
+            session,
+            sample_campaign,
+            JobStatus.CANCELLED,
+        )
+        service = JobQueryService(session)
+        with pytest.raises(ValueError, match="cannot be retried"):
+            service.retry_job(job.id)

--- a/backend/tests/unit/services/test_job_query_service_retry.py
+++ b/backend/tests/unit/services/test_job_query_service_retry.py
@@ -14,7 +14,7 @@ from datetime import UTC, datetime, timedelta
 import pytest
 from sqlmodel import Session, SQLModel, create_engine
 
-from app.data.database.model.jobs import JobStatus, MatcherJob
+from app.data.database.model.jobs import JobStatus, MatcherJob, OcrJob
 from app.data.database.model.schema import Campaign, Region
 from app.services.job_query_service import JobQueryService
 
@@ -177,6 +177,50 @@ class TestRetryJobResetsOrphanState:
         result = service.retry_job(job.id)
 
         assert result.status == JobStatus.NOT_STARTED.value
+
+    def test_non_terminal_child_ocr_jobs_reset_to_not_started(
+        self, session, sample_campaign
+    ):
+        job = _create_job_with_status(
+            session,
+            sample_campaign,
+            JobStatus.OCR_STARTED,
+            started_on=datetime.now(UTC) - timedelta(minutes=6),
+        )
+        ocr_job = OcrJob(
+            matcher_job_id=job.id,
+            status=JobStatus.OCR_STARTED,
+        )
+        session.add(ocr_job)
+        session.commit()
+        session.refresh(ocr_job)
+
+        service = JobQueryService(session)
+        service.retry_job(job.id)
+
+        session.refresh(ocr_job)
+        assert ocr_job.status == JobStatus.NOT_STARTED
+
+    def test_terminal_child_ocr_jobs_preserved(self, session, sample_campaign):
+        job = _create_job_with_status(
+            session,
+            sample_campaign,
+            JobStatus.OCR_STARTED,
+            started_on=datetime.now(UTC) - timedelta(minutes=6),
+        )
+        ocr_job = OcrJob(
+            matcher_job_id=job.id,
+            status=JobStatus.OCR_COMPLETED,
+        )
+        session.add(ocr_job)
+        session.commit()
+        session.refresh(ocr_job)
+
+        service = JobQueryService(session)
+        service.retry_job(job.id)
+
+        session.refresh(ocr_job)
+        assert ocr_job.status == JobStatus.OCR_COMPLETED
 
 
 class TestRetryJobNotFound:


### PR DESCRIPTION
## Summary

Adds periodic orphan detection and recovery to the worker loop, plus a manual retry endpoint.

### Changes

- **Periodic orphan recovery** in worker loop — every 60s, detects jobs stuck in non-terminal states (`OCR_STARTED`, `OCR_COMPLETED`, `MATCHING_PENDING`, `MATCHING`) beyond a 5-minute threshold and resets them to `NOT_STARTED`
- **POST /api/jobs/{id}/retry** endpoint — manual recovery for failed or stuck jobs, resets job to `NOT_STARTED` and clears timing/error fields
- **Child OCR job reset** — `retry_job()` also resets non-terminal child `OcrJob` records to `NOT_STARTED` (terminal OCR jobs preserved)
- Startup orphan termination preserved for backward compatibility

### Design decisions

- Reset to `NOT_STARTED` (not error) — allows reprocessing instead of data loss
- 5-min stale threshold, 60-sec check interval
- `started_on` used as timeout baseline
- Startup termination preserved for backward compatibility

Closes #129