### PR TITLE
feat(observability): structured logging for JobQueryService and orphan recovery

### DIFF
--- a/backend/app/jobs/worker.py
+++ b/backend/app/jobs/worker.py
@@ -50,6 +50,20 @@ ORPHAN_CHECK_INTERVAL_SECONDS = 60
 ORPHAN_TIMEOUT_SECONDS = 300
 
 
+def _compute_stale_duration_seconds(started_on: datetime | None) -> float | None:
+    """Compute how long a job has been running, or None if never started.
+
+    Handles both timezone-aware (PostgreSQL) and timezone-naive (SQLite)
+    datetimes by normalizing to UTC before subtraction.
+    """
+    if started_on is None:
+        return None
+    now = datetime.now(UTC)
+    if started_on.tzinfo is None:
+        started_on = started_on.replace(tzinfo=UTC)
+    return (now - started_on).total_seconds()
+
+
 class JobWorker:
     """Background worker for processing MatcherJobs.
 
@@ -127,12 +141,15 @@ class JobWorker:
             for job in jobs:
                 orphans.append(job)
                 previous_status = job.current_status.value
+                now = datetime.now(UTC)
+                stale_duration_seconds = _compute_stale_duration_seconds(job.started_on)
                 job.current_status = terminal_state
-                job.ended_on = datetime.now(UTC)
+                job.ended_on = now
+                reason = f"Job stuck in {previous_status} after backend restart"
                 job.error_data = {
                     "message": f"Orphaned job terminated on restart (was {previous_status})",
                     "previous_status": previous_status,
-                    "timestamp": datetime.now(UTC).isoformat(),
+                    "timestamp": now.isoformat(),
                 }
 
                 child_ocr_jobs = session.exec(
@@ -158,6 +175,8 @@ class JobWorker:
                     previous_status=previous_status,
                     new_status=terminal_state.value,
                     campaign_id=str(job.campaign_id),
+                    stale_duration_seconds=stale_duration_seconds,
+                    reason=reason,
                 )
 
         if orphans:
@@ -226,15 +245,23 @@ class JobWorker:
         ]
 
         recovered = 0
+        now = datetime.now(UTC)
         for job in stale_jobs:
             previous_status = job.current_status.value
+            stale_duration_seconds = _compute_stale_duration_seconds(job.started_on)
             job.current_status = JobStatus.NOT_STARTED
             job.started_on = None
             job.ended_on = None
+            reason = (
+                f"Job stuck in {previous_status} for "
+                f"{stale_duration_seconds:.0f}s (exceeds {ORPHAN_TIMEOUT_SECONDS}s timeout)"
+                if stale_duration_seconds is not None
+                else f"Job stuck in {previous_status} with no started_on timestamp"
+            )
             job.error_data = {
                 "recovered": True,
                 "previous_status": previous_status,
-                "timestamp": datetime.now(UTC).isoformat(),
+                "timestamp": now.isoformat(),
             }
 
             child_ocr_jobs = session.exec(
@@ -250,7 +277,10 @@ class JobWorker:
                 "Orphaned job recovered",
                 job_id=job.id,
                 previous_status=previous_status,
+                new_status=JobStatus.NOT_STARTED.value,
                 campaign_id=str(job.campaign_id),
+                stale_duration_seconds=stale_duration_seconds,
+                reason=reason,
             )
             recovered += 1
 

--- a/backend/app/services/job_query_service.py
+++ b/backend/app/services/job_query_service.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import uuid
+
+import structlog
 from sqlmodel import Session, select
 
 from app.data.database.model.jobs import JobStatus, MatcherJob, OcrJob
@@ -10,6 +12,8 @@ from app.data.database.model.petition_scan import PetitionScan
 from app.data.database.model.schema import Campaign
 from app.data.database.model.voter_list_upload import UploadStatus, VoterListUpload
 from app.responses.jobs import JobListResponse, JobResponse
+
+logger = structlog.get_logger(__name__)
 
 _ORPHAN_STATES = frozenset(
     {
@@ -149,6 +153,13 @@ class JobQueryService:
         self._session.commit()
         self._session.refresh(job)
 
+        logger.info(
+            "Job created",
+            job_id=job.id,
+            campaign_id=str(campaign_id),
+            status=job.current_status.value,
+        )
+
         return self._build_job_response(job)
 
     def cancel_job(self, job_id: int) -> JobResponse:
@@ -172,10 +183,18 @@ class JobQueryService:
                 f"Job cannot be cancelled in state {job.current_status.value}"
             )
 
+        previous_status = job.current_status.value
         job.current_status = JobStatus.CANCELLED
         self._session.add(job)
         self._session.commit()
         self._session.refresh(job)
+
+        logger.info(
+            "Job cancelled",
+            job_id=job.id,
+            previous_status=previous_status,
+            new_status=job.current_status.value,
+        )
 
         return self._build_job_response(job)
 
@@ -206,10 +225,18 @@ class JobQueryService:
         if not petition_scans:
             raise ValueError("Cannot start job: Campaign has no petition scans")
 
+        previous_status = job.current_status.value
         job.current_status = JobStatus.OCR_PENDING
         self._session.add(job)
         self._session.commit()
         self._session.refresh(job)
+
+        logger.info(
+            "Job started",
+            job_id=job.id,
+            previous_status=previous_status,
+            new_status=job.current_status.value,
+        )
 
         return self._build_job_response(job)
 
@@ -234,6 +261,7 @@ class JobQueryService:
                 f"Job cannot be retried in state {job.current_status.value}"
             )
 
+        previous_status = job.current_status.value
         job.current_status = JobStatus.NOT_STARTED
         job.started_on = None
         job.ended_on = None
@@ -249,6 +277,13 @@ class JobQueryService:
         self._session.add(job)
         self._session.commit()
         self._session.refresh(job)
+
+        logger.info(
+            "Job retried",
+            job_id=job.id,
+            previous_status=previous_status,
+            new_status=job.current_status.value,
+        )
 
         return self._build_job_response(job)
 

--- a/backend/tests/unit/jobs/test_orphan_logging.py
+++ b/backend/tests/unit/jobs/test_orphan_logging.py
@@ -1,0 +1,275 @@
+"""Tests for enhanced structured logging in orphan recovery and termination.
+
+Verifies that _terminate_orphans_with_session and _recover_orphaned_jobs_with_session
+emit per-job log events with job_id, previous_status, stale_duration_seconds, and reason.
+
+Uses structlog.testing.capture_logs to assert on log output.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+import structlog
+from sqlmodel import Session, SQLModel, create_engine
+
+from app.data.database.model.jobs import JobStatus, MatcherJob
+from app.data.database.model.schema import Campaign, Region
+
+
+@pytest.fixture
+def engine():
+    eng = create_engine("sqlite:///:memory:", echo=False)
+    SQLModel.metadata.create_all(eng)
+    return eng
+
+
+@pytest.fixture
+def session(engine):
+    with Session(engine) as s:
+        yield s
+
+
+@pytest.fixture
+def sample_region(session):
+    region = Region(
+        region_key="DC",
+        region_name="Washington, DC",
+        country_code="US",
+    )
+    session.add(region)
+    session.commit()
+    session.refresh(region)
+    return region
+
+
+@pytest.fixture
+def sample_campaign(session, sample_region):
+    campaign = Campaign(
+        unique_name="orphan-log-test",
+        title="Orphan Log Test",
+        year="2025",
+        region_id=sample_region.id,
+    )
+    session.add(campaign)
+    session.commit()
+    session.refresh(campaign)
+    return campaign
+
+
+def _create_job(session, campaign, status, **kwargs):
+    job = MatcherJob(
+        campaign_id=campaign.id,
+        current_status=status,
+        **kwargs,
+    )
+    session.add(job)
+    session.commit()
+    session.refresh(job)
+    return job
+
+
+def _create_stale_job(session, campaign, status, minutes_stale=6):
+    job = MatcherJob(
+        campaign_id=campaign.id,
+        current_status=status,
+        started_on=datetime.now(UTC) - timedelta(minutes=minutes_stale),
+    )
+    session.add(job)
+    session.commit()
+    session.refresh(job)
+    return job
+
+
+class TestTerminateOrphansLogging:
+    """Feature: Enhanced logging for orphan termination on startup."""
+
+    def test_terminate_logs_per_job_fields(self, session, sample_campaign):
+        from app.jobs.worker import JobWorker
+
+        job = _create_job(
+            session,
+            sample_campaign,
+            JobStatus.OCR_STARTED,
+            started_on=datetime.now(UTC) - timedelta(minutes=10),
+        )
+        worker = JobWorker()
+
+        with structlog.testing.capture_logs() as cap_logs:
+            worker._terminate_orphans_with_session(session)
+
+        terminate_logs = [
+            entry for entry in cap_logs if entry["event"] == "Orphaned job terminated"
+        ]
+        assert len(terminate_logs) == 1
+        log = terminate_logs[0]
+        assert log["job_id"] == job.id
+        assert log["previous_status"] == "OCR_STARTED"
+        assert log["new_status"] == "OCR_FAILED"
+        assert log["campaign_id"] == str(job.campaign_id)
+        assert log["stale_duration_seconds"] is not None
+        assert log["stale_duration_seconds"] > 0
+        assert "reason" in log
+        assert "OCR_STARTED" in log["reason"]
+        assert log["log_level"] == "warning"
+
+    def test_terminate_logs_stale_duration_none_when_no_started_on(
+        self, session, sample_campaign
+    ):
+        from app.jobs.worker import JobWorker
+
+        # Job with no started_on (created but never started processing)
+        _create_job(session, sample_campaign, JobStatus.OCR_STARTED)
+        worker = JobWorker()
+
+        with structlog.testing.capture_logs() as cap_logs:
+            worker._terminate_orphans_with_session(session)
+
+        terminate_logs = [
+            entry for entry in cap_logs if entry["event"] == "Orphaned job terminated"
+        ]
+        assert len(terminate_logs) == 1
+        assert terminate_logs[0]["stale_duration_seconds"] is None
+
+    def test_terminate_logs_reason_mentions_restart(self, session, sample_campaign):
+        from app.jobs.worker import JobWorker
+
+        _create_job(
+            session,
+            sample_campaign,
+            JobStatus.MATCHING,
+            started_on=datetime.now(UTC) - timedelta(minutes=3),
+        )
+        worker = JobWorker()
+
+        with structlog.testing.capture_logs() as cap_logs:
+            worker._terminate_orphans_with_session(session)
+
+        terminate_logs = [
+            entry for entry in cap_logs if entry["event"] == "Orphaned job terminated"
+        ]
+        assert len(terminate_logs) == 1
+        assert "restart" in terminate_logs[0]["reason"].lower()
+
+    def test_terminate_no_orphans_no_per_job_logs(self, session, sample_campaign):
+        from app.jobs.worker import JobWorker
+
+        _create_job(session, sample_campaign, JobStatus.NOT_STARTED)
+        worker = JobWorker()
+
+        with structlog.testing.capture_logs() as cap_logs:
+            worker._terminate_orphans_with_session(session)
+
+        terminate_logs = [
+            entry for entry in cap_logs if entry["event"] == "Orphaned job terminated"
+        ]
+        assert len(terminate_logs) == 0
+
+
+class TestRecoverOrphansLogging:
+    """Feature: Enhanced logging for periodic orphan recovery."""
+
+    def test_recover_logs_per_job_fields(self, session, sample_campaign):
+        from app.jobs.worker import JobWorker
+
+        job = _create_stale_job(
+            session, sample_campaign, JobStatus.OCR_STARTED, minutes_stale=6
+        )
+        worker = JobWorker()
+
+        with structlog.testing.capture_logs() as cap_logs:
+            worker._recover_orphaned_jobs_with_session(session)
+
+        recover_logs = [
+            entry for entry in cap_logs if entry["event"] == "Orphaned job recovered"
+        ]
+        assert len(recover_logs) == 1
+        log = recover_logs[0]
+        assert log["job_id"] == job.id
+        assert log["previous_status"] == "OCR_STARTED"
+        assert log["new_status"] == "NOT_STARTED"
+        assert log["campaign_id"] == str(job.campaign_id)
+        assert log["stale_duration_seconds"] is not None
+        assert log["stale_duration_seconds"] > 0
+        assert "reason" in log
+        assert "OCR_STARTED" in log["reason"]
+
+    def test_recover_logs_stale_duration_none_when_no_started_on(
+        self, session, sample_campaign
+    ):
+        from app.jobs.worker import JobWorker
+
+        # Job with null started_on — query hits the `started_on.is_(None)` branch
+        job = MatcherJob(
+            campaign_id=sample_campaign.id,
+            current_status=JobStatus.OCR_STARTED,
+            started_on=None,
+        )
+        session.add(job)
+        session.commit()
+        session.refresh(job)
+        worker = JobWorker()
+
+        with structlog.testing.capture_logs() as cap_logs:
+            worker._recover_orphaned_jobs_with_session(session)
+
+        recover_logs = [
+            entry for entry in cap_logs if entry["event"] == "Orphaned job recovered"
+        ]
+        assert len(recover_logs) == 1
+        assert recover_logs[0]["stale_duration_seconds"] is None
+        assert "no started_on" in recover_logs[0]["reason"]
+
+    def test_recover_logs_reason_mentions_timeout(self, session, sample_campaign):
+        from app.jobs.worker import JobWorker
+
+        _create_stale_job(
+            session, sample_campaign, JobStatus.MATCHING, minutes_stale=10
+        )
+        worker = JobWorker()
+
+        with structlog.testing.capture_logs() as cap_logs:
+            worker._recover_orphaned_jobs_with_session(session)
+
+        recover_logs = [
+            entry for entry in cap_logs if entry["event"] == "Orphaned job recovered"
+        ]
+        assert len(recover_logs) == 1
+        assert "timeout" in recover_logs[0]["reason"].lower()
+
+    def test_recover_no_stale_jobs_no_logs(self, session, sample_campaign):
+        from app.jobs.worker import JobWorker
+
+        _create_job(
+            session,
+            sample_campaign,
+            JobStatus.OCR_STARTED,
+            started_on=datetime.now(UTC) - timedelta(seconds=30),
+        )
+        worker = JobWorker()
+
+        with structlog.testing.capture_logs() as cap_logs:
+            worker._recover_orphaned_jobs_with_session(session)
+
+        recover_logs = [
+            entry for entry in cap_logs if entry["event"] == "Orphaned job recovered"
+        ]
+        assert len(recover_logs) == 0
+
+    def test_recover_multiple_jobs_each_logged(self, session, sample_campaign):
+        from app.jobs.worker import JobWorker
+
+        _create_stale_job(
+            session, sample_campaign, JobStatus.OCR_STARTED, minutes_stale=6
+        )
+        _create_stale_job(session, sample_campaign, JobStatus.MATCHING, minutes_stale=8)
+        worker = JobWorker()
+
+        with structlog.testing.capture_logs() as cap_logs:
+            worker._recover_orphaned_jobs_with_session(session)
+
+        recover_logs = [
+            entry for entry in cap_logs if entry["event"] == "Orphaned job recovered"
+        ]
+        assert len(recover_logs) == 2
+        statuses = {entry["previous_status"] for entry in recover_logs}
+        assert statuses == {"OCR_STARTED", "MATCHING"}

--- a/backend/tests/unit/services/test_job_query_service_logging.py
+++ b/backend/tests/unit/services/test_job_query_service_logging.py
@@ -1,0 +1,204 @@
+"""Tests for structured logging in JobQueryService.
+
+Verifies that state-changing operations (create, start, cancel, retry)
+emit structured log events with the correct fields.
+
+Uses structlog.testing.capture_logs to assert on log output without
+requiring the stdlib logging integration.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+import structlog
+from sqlmodel import Session, SQLModel, create_engine
+
+from app.data.database.model.jobs import JobStatus, MatcherJob
+from app.data.database.model.llm_provider_config import LlmProviderConfig
+from app.data.database.model.petition_scan import PetitionScan
+from app.data.database.model.schema import Campaign, Region
+from app.data.database.model.voter_list_upload import UploadStatus, VoterListUpload
+from app.services.job_query_service import JobQueryService
+
+
+@pytest.fixture
+def engine():
+    eng = create_engine("sqlite:///:memory:", echo=False)
+    SQLModel.metadata.create_all(eng)
+    return eng
+
+
+@pytest.fixture
+def session(engine):
+    with Session(engine) as s:
+        yield s
+
+
+@pytest.fixture
+def sample_region(session):
+    region = Region(
+        region_key="DC",
+        region_name="Washington, DC",
+        country_code="US",
+    )
+    session.add(region)
+    session.commit()
+    session.refresh(region)
+    return region
+
+
+@pytest.fixture
+def sample_campaign(session, sample_region):
+    campaign = Campaign(
+        unique_name="log-test",
+        title="Log Test",
+        year="2025",
+        region_id=sample_region.id,
+    )
+    session.add(campaign)
+    session.commit()
+    session.refresh(campaign)
+    return campaign
+
+
+def _seed_full_setup(session, campaign):
+    """Seed petition scan, voter list, and OCR provider config."""
+    region_id = campaign.region_id
+    scan = PetitionScan(
+        campaign_id=campaign.id,
+        original_filename="test.pdf",
+        stored_path="/tmp/test.pdf",
+        file_hash="abc123",
+        page_count=1,
+    )
+    session.add(scan)
+    upload = VoterListUpload(
+        region_id=region_id,
+        original_filename="voters.csv",
+        file_size=1024,
+        row_count=100,
+        status=UploadStatus.ACTIVE,
+    )
+    session.add(upload)
+    config = LlmProviderConfig(
+        provider="openai",
+        api_key="sk-test-key-for-unit-tests",  # pragma: allowlist secret
+        model="gpt-4o-mini",
+        is_configured=True,
+    )
+    session.add(config)
+    session.commit()
+
+
+def _create_job(session, campaign, status, **kwargs):
+    job = MatcherJob(
+        campaign_id=campaign.id,
+        current_status=status,
+        **kwargs,
+    )
+    session.add(job)
+    session.commit()
+    session.refresh(job)
+    return job
+
+
+class TestCreateJobLogging:
+    """Feature: Structured logging for job creation."""
+
+    def test_create_job_logs_event(self, session, sample_campaign):
+        _seed_full_setup(session, sample_campaign)
+        service = JobQueryService(session)
+
+        with structlog.testing.capture_logs() as cap_logs:
+            service.create_job(campaign_id=sample_campaign.id)
+
+        create_logs = [entry for entry in cap_logs if entry["event"] == "Job created"]
+        assert len(create_logs) == 1
+        log = create_logs[0]
+        assert log["job_id"] is not None
+        assert log["status"] == "NOT_STARTED"
+        assert log["campaign_id"] == str(sample_campaign.id)
+        assert log["log_level"] == "info"
+
+
+class TestCancelJobLogging:
+    """Feature: Structured logging for job cancellation."""
+
+    def test_cancel_job_logs_status_transition(self, session, sample_campaign):
+        job = _create_job(session, sample_campaign, JobStatus.NOT_STARTED)
+        service = JobQueryService(session)
+
+        with structlog.testing.capture_logs() as cap_logs:
+            service.cancel_job(job.id)
+
+        cancel_logs = [entry for entry in cap_logs if entry["event"] == "Job cancelled"]
+        assert len(cancel_logs) == 1
+        log = cancel_logs[0]
+        assert log["job_id"] == job.id
+        assert log["previous_status"] == "NOT_STARTED"
+        assert log["new_status"] == "CANCELLED"
+        assert log["log_level"] == "info"
+
+
+class TestStartJobLogging:
+    """Feature: Structured logging for job start."""
+
+    def test_start_job_logs_status_transition(self, session, sample_campaign):
+        _seed_full_setup(session, sample_campaign)
+        job = _create_job(session, sample_campaign, JobStatus.NOT_STARTED)
+        service = JobQueryService(session)
+
+        with structlog.testing.capture_logs() as cap_logs:
+            service.start_job(job.id)
+
+        start_logs = [entry for entry in cap_logs if entry["event"] == "Job started"]
+        assert len(start_logs) == 1
+        log = start_logs[0]
+        assert log["job_id"] == job.id
+        assert log["previous_status"] == "NOT_STARTED"
+        assert log["new_status"] == "OCR_PENDING"
+        assert log["log_level"] == "info"
+
+
+class TestRetryJobLogging:
+    """Feature: Structured logging for job retry."""
+
+    def test_retry_job_logs_status_transition(self, session, sample_campaign):
+        job = _create_job(
+            session,
+            sample_campaign,
+            JobStatus.OCR_FAILED,
+            error_data={"message": "OCR provider error"},
+        )
+        service = JobQueryService(session)
+
+        with structlog.testing.capture_logs() as cap_logs:
+            service.retry_job(job.id)
+
+        retry_logs = [entry for entry in cap_logs if entry["event"] == "Job retried"]
+        assert len(retry_logs) == 1
+        log = retry_logs[0]
+        assert log["job_id"] == job.id
+        assert log["previous_status"] == "OCR_FAILED"
+        assert log["new_status"] == "NOT_STARTED"
+        assert log["log_level"] == "info"
+
+    def test_retry_job_from_orphan_logs_status_transition(
+        self, session, sample_campaign
+    ):
+        job = _create_job(
+            session,
+            sample_campaign,
+            JobStatus.OCR_STARTED,
+            started_on=datetime.now(UTC) - timedelta(minutes=6),
+        )
+        service = JobQueryService(session)
+
+        with structlog.testing.capture_logs() as cap_logs:
+            service.retry_job(job.id)
+
+        retry_logs = [entry for entry in cap_logs if entry["event"] == "Job retried"]
+        assert len(retry_logs) == 1
+        log = retry_logs[0]
+        assert log["previous_status"] == "OCR_STARTED"
+        assert log["new_status"] == "NOT_STARTED"


### PR DESCRIPTION
## Summary

Add structured logging to `JobQueryService` so every state-changing job operation emits a log entry with the job ID and status transition. Enhance the worker's orphan recovery and termination logs to include how long each job was stuck and why it was acted on.

This closes the observability gap left by #152 (orphan recovery) — the worker had logging, but the service layer had none, and the orphan logs only mentioned counts.

### Changes

**`backend/app/services/job_query_service.py`** — New structlog logger. Four operations now log:

| Operation | Event | Fields |
|-----------|-------|--------|
| `create_job` | `Job created` | `job_id`, `campaign_id`, `status` |
| `start_job` | `Job started` | `job_id`, `previous_status`, `new_status` |
| `cancel_job` | `Job cancelled` | `job_id`, `previous_status`, `new_status` |
| `retry_job` | `Job retried` | `job_id`, `previous_status`, `new_status` |

**`backend/app/jobs/worker.py`** — Enhanced per-job logs in orphan handling:

- `_terminate_orphans_with_session()`: added `stale_duration_seconds` (time since `started_on`) and `reason` ("Job stuck in {state} after backend restart")
- `_recover_orphaned_jobs_with_session()`: added `stale_duration_seconds`, `new_status`, and `reason` (mentions timeout threshold)
- Added `_compute_stale_duration_seconds()` helper — handles both timezone-aware (PostgreSQL) and timezone-naive (SQLite) datetimes so tests and production both work

### Tests

Two new test files using `structlog.testing.capture_logs`:

- `test_job_query_service_logging.py` — 5 tests for create/cancel/start/retry log events and fields
- `test_orphan_logging.py` — 9 tests for terminate/recover, covering per-job fields, null `started_on`, reason text, and multi-job scenarios

### Verification

- `pytest` — 94 passed (14 new + 80 existing), 0 failed
- `ruff` — all checks passed
- `basedpyright` — 234 errors (improved from 314 baseline)
- Pre-commit hooks passed

Closes #36
