### PR TITLE
feat: enforce conventional commits via git hook, just commit, and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
       frontend: ${{ steps.filter.outputs.frontend }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Detect changed paths
         uses: dorny/paths-filter@v3
@@ -42,6 +44,9 @@ jobs:
 
       - name: Verify Bun runtime
         run: bun --version
+
+      - name: Check conventional commits
+        run: cd backend && uv sync --dev && uv run cz check --rev-range origin/main..HEAD
 
       - name: Check Python lockfile
         run: cd backend && uv lock --check
@@ -91,6 +96,7 @@ jobs:
           echo "## ❌ Prepare Checks Failed" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "One or more preparation checks failed. Check the failed step above for details." >> "$GITHUB_STEP_SUMMARY"
+          echo "- ❌ Conventional commits check failed" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Prepare success summary
         if: success()
@@ -102,6 +108,7 @@ jobs:
           echo "- ✅ JS lockfile (bun)" >> "$GITHUB_STEP_SUMMARY"
           echo "- ✅ Documentation validation" >> "$GITHUB_STEP_SUMMARY"
           echo "- ✅ Deploy config validation" >> "$GITHUB_STEP_SUMMARY"
+          echo "- ✅ Conventional commits validated" >> "$GITHUB_STEP_SUMMARY"
           if [[ "${{ steps.filter.outputs.backend }}" == "true" ]] || [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
             echo "- ✅ Justfile/Makefile sync" >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -142,14 +142,14 @@
         "filename": ".github/workflows/ci.yml",
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_verified": false,
-        "line_number": 705
+        "line_number": 712
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/ci.yml",
         "hashed_secret": "a128f45f1c9645b721090d0673e656ec295eaded",
         "is_verified": false,
-        "line_number": 705
+        "line_number": 712
       }
     ],
     "Makefile": [
@@ -311,5 +311,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-04T13:01:02Z"
+  "generated_at": "2026-08-15T23:18:40Z"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,5 +90,6 @@ If changing `AGENTS.md` or `docs/agents/**`, branch name must start with `agents
 
 - You may be in a dirty worktree. Do not revert or overwrite changes you did not make.
 - Check `git status --short --branch` before edits and before commits.
+- A `commit-msg` hook enforces Conventional Commit syntax on every commit; use `just commit` for a reliable way to produce a conforming message.
 - Create focused branches for non-trivial work.
 - Commit only when the user asks.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,13 +120,29 @@ just ci-sim
 
 ### 4. Commit
 
-Write clear, concise commit messages. Explain *why*, not just *what*.
+VoteCatcher enforces [Conventional Commits](https://www.conventionalcommits.org/) via a `commit-msg` hook (which runs `cz check`) and CI validation on PRs. All commit messages must follow the `type(scope): description` format.
+
+The recommended way to create a conforming commit is:
+
+```bash
+just commit
+```
+
+This interactive prompt guides you through a Conventional Commit message that will pass validation.
+
+Example commit message:
 
 ```
 fix(backend): handle empty voter file gracefully
 
 Previously, uploading an empty CSV would crash the matching service.
 Now returns a validation error to the client.
+```
+
+For critical hotfixes where the hook must be bypassed, use:
+
+```bash
+git commit --no-verify -m "hotfix: urgent security patch"
 ```
 
 ### 5. Push and Create PR

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # DO NOT EDIT - Generated from justfile by scripts/just-to-make.py
 # To update: python scripts/just-to-make.py > Makefile
 
-.PHONY: default stop install dev dev-backend dev-frontend dev-frontend-demo test lint typecheck clean docker-up docker-down dev-postgres dev-postgres-stop dev-postgres-clean docker-logs migrate migrate-down migrate-create db-reset security-scan security-scan-backend security-scan-frontend sast sast-pr sca container-scan docker-lint lint-backend lint-frontend typecheck-backend typecheck-frontend test-backend test-backend-integration security-test dast duplication duplication-frontend duplication-all complexity complexity-check dead-code dead-code-frontend fallow fallow-dead-code fallow-dupes fallow-health fallow-audit test-frontend sbom license-check edge-functions bundle-size benchmark ci-sim install-tools install-hooks validate-docs sync-makefile version version-set release changelog changelog-range changelog-preview changelog-summarize changelog-summarize-dry release-force release-prerelease release-stable
+.PHONY: default stop install dev dev-backend dev-frontend dev-frontend-demo test lint typecheck clean docker-up docker-down dev-postgres dev-postgres-stop dev-postgres-clean docker-logs migrate migrate-down migrate-create db-reset security-scan security-scan-backend security-scan-frontend sast sast-pr sca container-scan docker-lint lint-backend lint-frontend typecheck-backend typecheck-frontend test-backend test-backend-integration security-test dast duplication duplication-frontend duplication-all complexity complexity-check dead-code dead-code-frontend fallow fallow-dead-code fallow-dupes fallow-health fallow-audit test-frontend sbom license-check edge-functions bundle-size benchmark ci-sim install-tools install-hooks validate-docs sync-makefile version version-set commit release changelog changelog-range changelog-preview changelog-summarize changelog-summarize-dry release-force release-prerelease release-stable
 
 default:
 	@just --list
@@ -287,6 +287,9 @@ version-set:
 	@cd backend && uv lock
 	@echo "Updated: backend/pyproject.toml, frontend/package.json, .cz.toml, backend/uv.lock"
 	@echo "Verify:  just version"
+
+commit:
+	@cd backend && uv run cz commit
 
 release:
 	@cd backend && uv run cz bump --yes && git push --tags

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -86,9 +86,12 @@ bun run test               # Tests
 
 ### 4. Commit and Push
 
+The recommended way to commit is `just commit`, which opens an interactive prompt for creating a Conventional Commit message (validated by the `commit-msg` hook). If you prefer a direct commit, ensure your message follows the `type(scope): description` format:
+
 ```bash
 git add .
-git commit -m "feat: your feature description"
+just commit
+# or: git commit -m "feat(backend): your feature description"
 git push origin feature/your-feature-name
 ```
 

--- a/docs/development/versioning.md
+++ b/docs/development/versioning.md
@@ -44,6 +44,14 @@ All version commands use [just](https://github.com/casey/just):
 just version
 ```
 
+### Interactive conventional commit
+
+```bash
+just commit
+```
+
+Guides you through creating a Conventional Commit message via `cz check`. See [Commit Enforcement](#commit-enforcement) for details.
+
 ### Auto-bump (reads conventional commits)
 
 ```bash
@@ -142,6 +150,42 @@ feat(api)!: change /jobs response schema
 
 BREAKING CHANGE: jobs endpoint returns array instead of object.
 ```
+
+## Commit Enforcement
+
+A `commit-msg` hook runs `cz check` on every commit to enforce Conventional Commit syntax. Non-conforming commits are rejected by the hook.
+
+### Interactive commit creation
+
+Use the `just` recipe for interactive conventional commit creation:
+
+```bash
+just commit
+```
+
+This opens a prompt that guides you through selecting a type, scope, and message that will pass `cz check`.
+
+### CI enforcement
+
+CI validates commit messages on every PR:
+
+```yaml
+# .github/workflows/ci.yml
+- name: Check conventional commits
+  run: cd backend && uv sync --dev && uv run cz check --rev-range origin/main..HEAD
+```
+
+This checks all commits introduced by the PR against the Conventional Commit spec.
+
+### Bypassing the hook
+
+For critical hotfixes where the message must be written immediately, bypass the hook:
+
+```bash
+git commit --no-verify -m "hotfix: urgent security patch"
+```
+
+Bypass should be rare and the PR branch should be amended to a conventional commit message after the hotfix is staged, whenever possible.
 
 ## Configuration
 

--- a/justfile
+++ b/justfile
@@ -349,6 +349,10 @@ version-set version:
     @echo "Updated: backend/pyproject.toml, frontend/package.json, .cz.toml, backend/uv.lock"
     @echo "Verify:  just version"
 
+# Create an interactive conventional commit using commitizen
+commit:
+    @cd backend && uv run cz commit
+
 # Auto-bump version based on conventional commits since last tag
 release:
     @cd backend && uv run cz bump --yes && git push --tags


### PR DESCRIPTION
## Summary

Adds three layers of Conventional Commits enforcement to the project:

1. **Local git hook** — Validates every commit message against Conventional Commits rules via `cz check`. Registerd with portable path resolution so it works across all worktrees. Existing hooks retrofitted to the same portable pattern.
2. **`just commit` recipe** — Interactive conventional commit creation via `cz commit`.
3. **CI commit check** — Validates all commits on a PR branch with `cz check --rev-range origin/main..HEAD`.
4. **Documentation** — Updated versioning docs, CONTRIBUTING.md, development README, and AGENTS.md.

## Bypass

For hotfixes: `git commit --no-verify`

## Verification

- ✅ Hook rejects non-conventional commits, accepts conventional ones, auto-allows merge/revert
- ✅ `just commit` recipe functional
- ✅ CI workflow has correct steps
- ✅ All commits in this PR conform to conventional format
- ✅ `just ci-sim` — no regressions